### PR TITLE
vtermの追加

### DIFF
--- a/init.el
+++ b/init.el
@@ -295,6 +295,27 @@
   ("C-c v t" . vterm)              ; 新しい vterm を開く
   ("C-c v o" . vterm-other-window)) ; 別ウィンドウで開く
 
+;; vterm-toggle: vterm をトグル表示するパッケージ
+;; エディタ画面を保ちながら下部にターミナルを出し入れできる
+;; VSCode のターミナルパネルに近い感覚で使える
+(use-package vterm-toggle
+  :after vterm
+  :config
+  ;; ターミナルを画面下部に表示する
+  (setq vterm-toggle-fullscreen-p nil)
+  (add-to-list 'display-buffer-alist
+               '((lambda (buf actions)
+                   (with-current-buffer buf (equal major-mode 'vterm-mode)))
+                 (display-buffer-reuse-window display-buffer-at-bottom)
+                 (dedicated . t)
+                 (reusable-frames . visible)
+                 (window-height . 0.3))) ; 画面の30%の高さで表示
+
+  :bind
+  ("C-c v v" . vterm-toggle)             ; ターミナルの表示/非表示
+  ("C-c v n" . vterm-toggle-forward)     ; 次のターミナルへ
+  ("C-c v p" . vterm-toggle-backward))   ; 前のターミナルへ
+
  ;;; ============================================================
 ;;; プロジェクト管理
 ;;; ============================================================
@@ -322,7 +343,7 @@
  ;; If there is more than one, they won't work right.
  '(package-selected-packages
    '(corfu forge git-gutter magit marginalia orderless swift-mode
-           treesit-auto typescript-mode vertico vterm
+           treesit-auto typescript-mode vertico vterm vterm-toggle
            yasnippet-snippets)))
 (custom-set-faces
  ;; custom-set-faces was added by Custom.


### PR DESCRIPTION
# vterm とは
Emacs 内でターミナルを動かすための仕組みです。Emacs には標準で eshell や term がありますが、vterm は C言語で書かれたライブラリ（libvterm）をバインドするため、本物のターミナルに近い動作をします。

# 事前準備（ビルドに必要なツール）
vterm は初回起動時に C ライブラリをコンパイルするため、以下が必要です。

```sh
# macOS の場合
brew install cmake libvterm
```


