### PR TITLE
eatターミナル統合・claude-code-ide設定強化・vterm表示改善

### DIFF
--- a/init.el
+++ b/init.el
@@ -136,11 +136,20 @@
   (eshell-load . eat-eshell-mode)
 
   :config
-  ;; zsh のシェル統合を有効化（ディレクトリ追跡・コマンド認識）
-  ;; ~/.zshrc に以下を追加してください:
-  ;;   [ -n "$EAT_SHELL_INTEGRATION_DIR" ] && \
-  ;;     source "$EAT_SHELL_INTEGRATION_DIR/zsh"
-  )
+  ;; global-display-line-numbers-mode の内部 turn-on 関数をアドバイス
+  ;; hook の実行順序に依存せず、eat バッファへの有効化を根本から阻止する
+  (with-eval-after-load 'display-line-numbers
+    (advice-add 'display-line-numbers--turn-on :around
+                (lambda (orig-fn)
+                  (unless (derived-mode-p 'eat-mode)
+                    (funcall orig-fn)))))
+
+  ;; eat バッファの表示をターミナルに近づける
+  (add-hook 'eat-mode-hook
+            (lambda ()
+              (display-line-numbers-mode -1) ; 行番号を無効化
+              (hl-line-mode -1)              ; カーソル行ハイライトを無効化
+              (setq-local cursor-in-non-selected-windows nil))))
 
 ;;; ============================================================
 ;;; claude-code-ide
@@ -149,10 +158,9 @@
 
 (use-package claude-code-ide
   :straight (:type git :host github :repo "manzaltu/claude-code-ide.el")
-  :after eat
 
   :custom
-  ;; ターミナルバックエンド: eat を使用
+  ;; ターミナルバックエンド: eat
   (claude-code-ide-terminal-backend 'eat)
   ;; Claude ウィンドウを右側に表示（'right / 'left / 'bottom / 'top）
   (claude-code-ide-window-side 'right)
@@ -445,6 +453,12 @@
   ;; vterm バッファを閉じた時、ウィンドウも一緒に閉じる
   ;; ターミナルを exit した後に空のバッファが残らないようにする
   (setq vterm-kill-buffer-on-exit t)
+
+  ;; vterm バッファでは行番号・hl-line を無効化する
+  ;; vterm-mode-hook は after-change-major-mode-hook より後に実行されるため確実
+  (add-hook 'vterm-mode-hook (lambda ()
+                               (display-line-numbers-mode -1)
+                               (hl-line-mode -1)))
 
   :bind
   ("C-c v t" . vterm)              ; 新しい vterm を開く


### PR DESCRIPTION
## 変更内容

- **eatパッケージを追加**：純Emacs Lisp製ターミナルエミュレータ `eat`（Emulate A Terminal）を導入し、`xterm-256color` 互換モードで設定
- **claude-code-ideのバックエンドをeatに変更**：ターミナルバックエンドとして `vterm` から `eat` へ切り替え
- **claude-code-ideのキーバインドを拡張**：`C-c A s/c/r/b` のキーバインドを追加し、Claude の起動・継続・再開・バッファ切り替えを直接操作可能に
- **claude-code-ideのカスタム設定を追加**：ウィンドウ位置（右側表示）、ediff差分表示の有効化などを設定
- **eatバッファの行番号・hl-lineを無効化**：`advice-add` を使い `display-line-numbers--turn-on` をアドバイスすることで、hookの実行順序に依存せず `eat-mode` バッファへの有効化を根本から抑制
- **vtermバッファの行番号・hl-lineを無効化**：`vterm-mode-hook` に明示的に無効化処理を追加

## 変更理由

- vtermはCのネイティブモジュールに依存するため、環境によってビルドが困難なケースがある。eatは純Emacs Lispで実装されており、依存関係が少なく導入しやすい
- ターミナルバッファに行番号やカーソル行ハイライトが表示されるとノイズになるため、ターミナル系モードでは無効化が望ましい
- `global-display-line-numbers-mode` はhookを通じて全バッファに適用されるため、モードhookで後から無効化するだけでは競合が生じる場合がある。`advice-add` によるアドバイスで根本から制御することで、より確実に無効化できる
- claude-code-ideのキーバインドを整理し、よく使う操作へのアクセスを改善した

## 備考

- vtermの設定は残しており、必要に応じて引き続き利用可能
- eshell内でeatを使う場合は `eat-eshell-mode` フックが有効になる
- `claude-code-ide-use-ide-diff t` によりファイル差分の確認にediffが使用される