### PR TITLE
ターミナルエミュレータをvtermからeatに移行し、claude-code-ideの設定を拡充

### DIFF
--- a/init.el
+++ b/init.el
@@ -444,56 +444,13 @@
   (which-key-mode))
 
 ;;; ============================================================
-;;; vterm（ターミナルエミュレータ）
+;;; eat ターミナル キーバインド
 ;;; ============================================================
 
-(use-package vterm
-  :commands vterm ; vterm コマンドが呼ばれた時だけ読み込む（遅延読み込み）
-
-  :config
-  ;; シェルの設定
-  ;; Emacs は $SHELL 環境変数からシェルを自動検出するが
-  ;; 明示的に指定することで確実に希望のシェルが起動する
-  (setq vterm-shell (getenv "SHELL"))
-
-  ;; ターミナルの最大スクロール行数
-  ;; 大きくすると過去の出力を遡れるがメモリを使う
-  (setq vterm-max-scrollback 10000)
-
-  ;; vterm バッファを閉じた時、ウィンドウも一緒に閉じる
-  ;; ターミナルを exit した後に空のバッファが残らないようにする
-  (setq vterm-kill-buffer-on-exit t)
-
-  ;; vterm バッファでは行番号・hl-line を無効化する
-  ;; vterm-mode-hook は after-change-major-mode-hook より後に実行されるため確実
-  (add-hook 'vterm-mode-hook (lambda ()
-                               (display-line-numbers-mode -1)
-                               (hl-line-mode -1)))
-
-  :bind
-  ("C-c v t" . vterm)              ; 新しい vterm を開く
-  ("C-c v o" . vterm-other-window)) ; 別ウィンドウで開く
-
-;; vterm-toggle: vterm をトグル表示するパッケージ
-;; エディタ画面を保ちながら下部にターミナルを出し入れできる
-;; VSCode のターミナルパネルに近い感覚で使える
-(use-package vterm-toggle
-  :after vterm
-  :config
-  ;; ターミナルを画面下部に表示する
-  (setq vterm-toggle-fullscreen-p nil)
-  (add-to-list 'display-buffer-alist
-               '((lambda (buf actions)
-                   (with-current-buffer buf (equal major-mode 'vterm-mode)))
-                 (display-buffer-reuse-window display-buffer-at-bottom)
-                 (dedicated . t)
-                 (reusable-frames . visible)
-                 (window-height . 0.3))) ; 画面の30%の高さで表示
-
-  :bind
-  ("C-c v v" . vterm-toggle)             ; ターミナルの表示/非表示
-  ("C-c v n" . vterm-toggle-forward)     ; 次のターミナルへ
-  ("C-c v p" . vterm-toggle-backward))   ; 前のターミナルへ
+;; C-c v t : 新しい eat ターミナルを開く
+(global-set-key (kbd "C-c v t") #'eat)
+;; C-c v o : 別ウィンドウで eat を開く
+(global-set-key (kbd "C-c v o") #'eat-other-window)
 
  ;;; ============================================================
 ;;; プロジェクト管理


### PR DESCRIPTION
## 変更内容

- ターミナルエミュレータを `vterm` / `vterm-toggle` から `eat`（Emulate A Terminal）に移行
- `eat` パッケージを `use-package` で設定（`xterm-256color` 互換、eshell 統合含む）
- `eat` バッファでの行番号（`display-line-numbers`）およびカーソル行ハイライト（`hl-line`）を無効化
  - hook の実行順序に依存しないよう、`display-line-numbers--turn-on` に advice を適用する方式を採用
- `vterm` / `vterm-toggle` の設定・キーバインドを削除し、`C-c v t` / `C-c v o` を `eat` / `eat-other-window` に置き換え
- `claude-code-ide` のターミナルバックエンドを `eat` に設定し、ウィンドウ配置・ediff 差分表示などのカスタム設定を追加
- `claude-code-ide` のキーバインドを拡充（`C-c A s/c/r/b`）し、`claude-code-ide-emacs-tools-setup` を有効化

## 変更理由

- `vterm` は C 拡張モジュール（libvterm）のビルドが必要で、環境によってセットアップコストが高い。`eat` は純 Emacs Lisp 製のため依存関係が少なく、インストール・メンテナンスが容易
- `claude-code-ide` が `eat` バックエンドに対応しており、ターミナルエミュレータを統一することで設定の一貫性が向上する
- advice ベースの行番号制御により、hook の実行順序に起因する意図しない有効化を確実に防止できる

## 備考

- キーバインドの `C-c v *` プレフィックスは従来の `vterm` 系と同じ体系を維持しているため、操作感は変わらない
- `vterm-toggle` が提供していたトグル表示機能（下部パネル）は現時点では未設定。必要であれば別途 `eat` 向けに `display-buffer-alist` を追加する