### PR TITLE
MagitにAIコミットメッセージ生成機能とディレクトリ選択によるステータス起動機能を追加

### DIFF
--- a/init.el
+++ b/init.el
@@ -426,6 +426,66 @@
   ("C-c v s" . git-gutter:stage-hunk))   ; この変更だけをステージング
 
 ;;; ============================================================
+;;; Claude Code CLIでコミットメッセージを生成する
+;;; ============================================================
+(defun my/ai-commit--generate-message (&optional detail)
+  "Claude CLI を呼んでコミットメッセージを生成する。
+DETAIL が non-nil なら詳細形式（本文付き）、nil なら一行形式。
+戻り値: 生成されたコミットメッセージ文字列（trim済み）"
+  (let ((prompt
+         (if detail
+             ;; --detail モード: 一行要約 + 空行 + 箇条書き本文
+             "Generate a Git commit message in Japanese based strictly on the contents of `git diff --cached`. \
+Format it as follows: First line: a concise one-line summary. \
+Then a blank line. \
+Then a detailed bullet-point list explaining what was changed and why. \
+Output ONLY the commit message, no extra explanation."
+             ;; 通常モード: 一行のみ
+             "Generate ONLY a one-line Git commit message in Japanese. \
+The message should summarize what was changed and why, based strictly on the contents of `git diff --cached`. \
+DO NOT add an explanation or a body. Output ONLY the commit summary line.")))
+    ;; ユーザーに処理中であることを伝える（claude は数秒かかる）
+    (message "🤖 Generating AI commit message...")
+    (string-trim
+     (shell-command-to-string
+      (format "claude --no-session-persistence --print %s"
+              (shell-quote-argument prompt))))))
+
+
+(defun my/ai-commit ()
+  "一行形式のAIコミットメッセージを生成し、Magitのコミット編集バッファを開く。"
+  (interactive)
+  (let ((msg (my/ai-commit--generate-message nil)))
+    (if (string-empty-p msg)
+        (user-error "AI commit message generation failed (empty output)")
+      ;; magit-commit-create は内部で git commit を with-editor 経由で起動する。
+      ;; --message で初期メッセージを渡し、--edit でエディタを必ず開かせる。
+      (magit-commit-create (list (concat "--message=" msg) "--edit")))))
+
+
+(defun my/ai-commit-detail ()
+  "詳細形式（本文付き）のAIコミットメッセージを生成し、Magitのコミット編集バッファを開く。"
+  (interactive)
+  (let ((msg (my/ai-commit--generate-message t)))
+    (if (string-empty-p msg)
+        (user-error "AI commit message generation failed (empty output)")
+      (magit-commit-create (list (concat "--message=" msg) "--edit")))))
+
+
+;; ─────────────────────────────────────────────
+;; Magit の commit transient に追加
+;; ─────────────────────────────────────────────
+;; magit-commit を c で開いたときのメニューに A / D を追加する。
+;; transient-append-suffix の第2引数 "c" は「通常コミット」の直後に挿入することを意味する。
+
+(with-eval-after-load 'magit-commit
+  (transient-append-suffix 'magit-commit "c"
+    '("A" "AI commit (one-line)"  my/ai-commit))
+  (transient-append-suffix 'magit-commit "A"
+    '("D" "AI commit (detail)"    my/ai-commit-detail)))
+
+
+;;; ============================================================
 ;;; magit-gh
 ;;; ============================================================
 (use-package magit-gh


### PR DESCRIPTION
## 変更内容

- `forge` パッケージを削除
- `magit-status-ask-dir` 関数を追加：バッファに依存せず、常にディレクトリを明示的に入力して Magit を起動できるようにした
- Magit のコミットトランジェント (`c` メニュー) に Claude CLI を使った AI コミットメッセージ生成コマンドを追加
  - `A`: 一行コミットメッセージを生成 (`my/ai-commit`)
  - `D`: 詳細コミットメッセージを生成 (`my/ai-commit-detail`)

## 変更理由

- `forge` は現在使用しておらず、不要な依存を整理するために削除した
- `magit-status` はデフォルトでカレントバッファのリポジトリを開くため、バッファの状態によって意図しないリポジトリが開かれることがあった。明示的にディレクトリを指定できる関数を設けることで、常に目的のリポジトリを確実に開けるようにした
- コミットメッセージの作成コストを下げるため、Claude CLI と Magit を統合し、ステージング済みの差分をもとに AI がメッセージを自動生成できる仕組みを導入した

## 備考

- `my/ai-commit` および `my/ai-commit-detail` の実装は別途 `init.el` 内で定義済みであることを前提とする
- AI コミット機能は `magit-commit` ロード後に `with-eval-after-load` で遅延評価されるため、起動時のパフォーマンスへの影響はない