### PR TITLE
HackGen Console NFフォントと日本語環境を設定し、TUIレイアウト崩れを修正

### DIFF
--- a/init.el
+++ b/init.el
@@ -83,6 +83,24 @@
 ;; クリップボードをOSと共有する
 (setq select-enable-clipboard t)
 
+;;; ============================================================
+;;; フォント設定
+;;; ============================================================
+;; HackGen Console NF: Nerd Fonts 対応版（TUI アイコンも表示可能）
+;; インストール: brew install font-hackgen-nerd
+(when (display-graphic-p)
+  (let ((font (if (find-font (font-spec :name "HackGen Console NF"))
+                  "HackGen Console NF"
+                "HackGen Console")))
+    ;; 既定フォント（ASCII・Latin）
+    (set-face-attribute 'default nil :family font :height 140)
+    ;; 新規フレームにも同フォントを適用
+    (add-to-list 'default-frame-alist `(font . ,(concat font "-14")))
+    ;; 日本語（CJK）フォントも HackGen に統一
+    (set-fontset-font t 'japanese-jisx0208 (font-spec :family font))
+    (set-fontset-font t 'japanese-jisx0212 (font-spec :family font))
+    (set-fontset-font t 'katakana-jisx0201 (font-spec :family font))))
+
 ;; ダークテーマ（高コントラスト設定で半透明背景でも読みやすくする）
 (setq modus-themes-bold-constructs t)    ; 予約語・キーワードを太字に
 (setq modus-themes-italic-constructs t) ; コメント・ドキュメントをイタリックに


### PR DESCRIPTION
## 変更内容

- `set-language-environment "Japanese"` と `prefer-coding-system 'utf-8` を追加し、日本語環境を明示的に設定
- HackGen Console NF フォントの設定を追加（Nerd Fonts 対応版、フォールバックとして HackGen Console を使用）
  - ASCII・Latin・日本語（CJK）文字を HackGen フォントに統一
  - `japanese-jisx0208` / `japanese-jisx0212` / `katakana-jisx0201` の各フォントセットを設定
- vterm / eshell フック内で曖昧幅文字（Ambiguous Width Characters）を半角幅に固定
  - 対象: Box Drawing、Block Elements、Geometric Shapes、Miscellaneous Symbols、Dingbats、Nerd Fonts Private Use Area

## 変更理由

- 日本語環境を設定すると曖昧幅文字が全角扱いになり、罫線や Nerd Font アイコンを使う TUI アプリケーション（vterm・eshell 内の各種 CLI ツール）のレイアウトが崩れる問題があった
- HackGen Console NF は日本語と英数字の幅比が 2:1 に設計されており、ターミナル表示において日英混在テキストの位置ずれを防げるため採用

## 備考

- HackGen Console NF は `brew install font-hackgen-nerd` でインストール可能
- フォントが未インストールの場合は自動的に `HackGen Console` にフォールバックする
- 曖昧幅文字の半角固定は `char-width-table` をバッファローカルで変更しており、通常の Emacs バッファには影響しない