### PR TITLE
feat(keybindings): C-SPCをIME切り替え、C-\をMarkに再割り当て

### DIFF
--- a/init.el
+++ b/init.el
@@ -570,6 +570,13 @@ DO NOT add an explanation or a body. Output ONLY the commit summary line."))
 
 ;; macOS: Cmd+V でペースト
 (global-set-key (kbd "s-v") #'yank)
+
+;; IME切り替えとMarkのキーバインドを入れ替える
+;; 理由: macOSのデフォルトIME切り替えが C-SPC のため、Emacsでも統一する
+;; C-SPC → IME切り替え（toggle-input-method）
+;; C-\   → Mark（set-mark-command）
+(global-set-key (kbd "C-SPC") #'toggle-input-method)
+(global-set-key (kbd "C-\\")  #'set-mark-command)
 (custom-set-variables
  ;; custom-set-variables was added by Custom.
  ;; If you edit it by hand, you could mess it up, so be careful.


### PR DESCRIPTION
## 変更内容

`init.el` にて、IME切り替えとMarkのキーバインドを入れ替えた。

- `C-SPC` → `toggle-input-method`（IME切り替え）
- `C-\` → `set-mark-command`（Mark）

## 変更理由

macOSのデフォルトIME切り替えショートカットが `C-SPC` であるため、Emacs上でも同じキーでIMEを切り替えられるよう統一した。これにより、macOSネイティブの操作感とEmacs操作の一貫性が向上する。

## 備考

- 変更前はEmacsデフォルトの `C-SPC` がMarkに割り当てられており、日本語入力時に競合が発生していた。
- Markは `C-\` に移動したため、従来の `C-\`（`toggle-input-method`）との入れ替えとなる。