### PR TITLE
フレームの透明化・Vibrancy設定を削除してUIをシンプル化

### DIFF
--- a/early-init.el
+++ b/early-init.el
@@ -7,11 +7,4 @@
 ;; 起動時のフレームパラメータを事前設定することで
 ;; UIのちらつきを防ぐ
 (setq default-frame-alist
-      '((tool-bar-lines . nil)         ; ツールバー非表示
-        (menu-bar-lines . 1)         ; メニューバー非表示
-        (vertical-scroll-bars . nil) ; スクロールバー非表示
-        (alpha . (92 . 80))))        ; フレーム全体を半透明（アクティブ:92%, 非アクティブ:80%）
-;; macOSのVibrancy APIを使ってブラーをかける
-;; 引数は見た目のスタイル（'active が最も一般的）
-(add-to-list 'default-frame-alist '(ns-appearance . dark))
-(add-to-list 'default-frame-alist '(ns-transparent-titlebar . t))
+      '((menu-bar-lines . 1)))        ; メニューバー表示

--- a/init.el
+++ b/init.el
@@ -117,14 +117,6 @@
 (setq modus-themes-italic-constructs t) ; コメント・ドキュメントをイタリックに
 (load-theme 'modus-vivendi t)
 
-;; フレームの透明度設定
-;; alpha の値: (アクティブ時 . 非アクティブ時) 0〜100
-(add-to-list 'default-frame-alist '(alpha . (75 . 75)))
-
-;; Vibrancy（ブラー）を有効化;; 'active = アクティブウィンドウのみブラー
-(add-to-list 'default-frame-alist '(ns-use-thin-smoothing . t))
-(set-frame-parameter nil 'ns-transparent-titlebar t)
-(set-frame-parameter nil 'ns-appearance 'dark)
 
 ;;; ============================================================
 ;;; 外観（透明化・ガラス効果）


### PR DESCRIPTION
## 変更内容

`early-init.el` および `init.el` から、フレームの透明化（`alpha`）および macOS の Vibrancy（ブラー効果）に関する設定をすべて削除した。

具体的には以下の設定を除去:
- `alpha` による半透明設定（アクティブ: 92%/75%, 非アクティブ: 80%/75%）
- `ns-appearance` / `ns-transparent-titlebar` による macOS ダークモード連携
- `ns-use-thin-smoothing` による Vibrancy 効果

また、`default-frame-alist` はメニューバー表示の設定のみを残すようシンプル化した。

<img width="1352" height="878" alt="スクリーンショット 2026-03-14 19 48 41" src="https://github.com/user-attachments/assets/2065e89b-72ca-47ff-b9a1-4ce10081485a" />



## 変更理由

透明化・Vibrancy 設定がオリジナルの UI デザインとして不要と判断したため、削除してシンプルな外観設定に戻した。

## 備考

- ツールバー非表示（`tool-bar-lines`）やスクロールバー非表示（`vertical-scroll-bars`）の設定も `early-init.el` から除去されているが、これらは別の箇所で管理されているか、デフォルト動作に委ねる方針と思われる。確認が必要であれば別途対応する。