### PR TITLE
外部ターミナルで Claude Code を起動する open-terminal.el を追加

### DIFF
--- a/init.el
+++ b/init.el
@@ -608,6 +608,41 @@ DO NOT add an explanation or a body. Output ONLY the commit summary line."))
 (global-set-key (kbd "C-SPC") #'toggle-input-method)
 (global-set-key (kbd "C-\\")  #'set-mark-command)
 
+;;; ============================================================
+;;; Claude Code を外部ターミナルで開く
+;;; ============================================================
+
+(defun my/open-terminal-with-command (dir command)
+  "DIR をカレントディレクトリとして COMMAND を外部ターミナルで非同期実行する。
+優先順位: WezTerm → Ghostty → Terminal.app"
+  (let ((wezterm "/opt/homebrew/bin/wezterm"))
+    (cond
+     ;; WezTerm: CLI が利用可能
+     ((file-executable-p wezterm)
+      (start-process "claude-terminal" nil
+                     wezterm "start" "--cwd" dir "--" "bash" "-c" command))
+     ;; Ghostty: open コマンド経由（--working-directory オプションは非対応のため
+     ;;          osascript で新規ウィンドウを開いてコマンドを送る）
+     ((file-directory-p "~/Applications/Ghostty.app")
+      (start-process "claude-terminal" nil
+                     "osascript" "-e"
+                     (format "tell application \"Ghostty\" to activate")))
+     ;; Terminal.app: フォールバック
+     (t
+      (start-process "claude-terminal" nil
+                     "osascript" "-e"
+                     (format "tell application \"Terminal\" to do script \"cd %s && %s\""
+                             (shell-quote-argument dir) command))))))
+
+(defun open-claude-code ()
+  "現在のバッファのディレクトリで Claude Code を外部ターミナルで開く。"
+  (interactive)
+  (let ((dir (expand-file-name default-directory)))
+    (my/open-terminal-with-command dir "claude")
+    (message "Claude Code を起動しました: %s" dir)))
+
+(global-set-key (kbd "C-c A t") #'open-claude-code)
+
 (custom-set-variables
  ;; custom-set-variables was added by Custom.
  ;; If you edit it by hand, you could mess it up, so be careful.

--- a/init.el
+++ b/init.el
@@ -620,9 +620,10 @@ DO NOT add an explanation or a body. Output ONLY the commit summary line."))
      ;; WezTerm: CLI が利用可能
      ((file-executable-p wezterm)
       (start-process "claude-terminal" nil
-                     wezterm "start" "--cwd" dir "--" "bash" "-c" command))
-     ;; Ghostty: open コマンド経由（--working-directory オプションは非対応のため
-     ;;          osascript で新規ウィンドウを開いてコマンドを送る）
+                     wezterm "start" "--cwd" dir "--" "bash" "-c" command)
+      (start-process "claude-terminal-focus" nil
+                     "osascript" "-e" "tell application \"WezTerm\" to activate"))
+     ;; Ghostty: osascript で新規ウィンドウを開いてコマンドを送る
      ((file-directory-p "~/Applications/Ghostty.app")
       (start-process "claude-terminal" nil
                      "osascript" "-e"
@@ -632,7 +633,9 @@ DO NOT add an explanation or a body. Output ONLY the commit summary line."))
       (start-process "claude-terminal" nil
                      "osascript" "-e"
                      (format "tell application \"Terminal\" to do script \"cd %s && %s\""
-                             (shell-quote-argument dir) command))))))
+                             (shell-quote-argument dir) command))
+      (start-process "claude-terminal-focus" nil
+                     "osascript" "-e" "tell application \"Terminal\" to activate")))))
 
 (defun open-claude-code ()
   "現在のバッファのディレクトリで Claude Code を外部ターミナルで開く。"

--- a/init.el
+++ b/init.el
@@ -612,39 +612,8 @@ DO NOT add an explanation or a body. Output ONLY the commit summary line."))
 ;;; Claude Code を外部ターミナルで開く
 ;;; ============================================================
 
-(defun my/open-terminal-with-command (dir command)
-  "DIR をカレントディレクトリとして COMMAND を外部ターミナルで非同期実行する。
-優先順位: WezTerm → Ghostty → Terminal.app"
-  (let ((wezterm "/opt/homebrew/bin/wezterm"))
-    (cond
-     ;; WezTerm: CLI が利用可能
-     ((file-executable-p wezterm)
-      (start-process "claude-terminal" nil
-                     wezterm "start" "--cwd" dir "--" "bash" "-c" command)
-      (start-process "claude-terminal-focus" nil
-                     "osascript" "-e" "tell application \"WezTerm\" to activate"))
-     ;; Ghostty: osascript で新規ウィンドウを開いてコマンドを送る
-     ((file-directory-p "~/Applications/Ghostty.app")
-      (start-process "claude-terminal" nil
-                     "osascript" "-e"
-                     (format "tell application \"Ghostty\" to activate")))
-     ;; Terminal.app: フォールバック
-     (t
-      (start-process "claude-terminal" nil
-                     "osascript" "-e"
-                     (format "tell application \"Terminal\" to do script \"cd %s && %s\""
-                             (shell-quote-argument dir) command))
-      (start-process "claude-terminal-focus" nil
-                     "osascript" "-e" "tell application \"Terminal\" to activate")))))
-
-(defun open-claude-code ()
-  "現在のバッファのディレクトリで Claude Code を外部ターミナルで開く。"
-  (interactive)
-  (let ((dir (expand-file-name default-directory)))
-    (my/open-terminal-with-command dir "claude")
-    (message "Claude Code を起動しました: %s" dir)))
-
-(global-set-key (kbd "C-c A t") #'open-claude-code)
+(add-to-list 'load-path (expand-file-name "lisp" user-emacs-directory))
+(require 'open-terminal)
 
 (custom-set-variables
  ;; custom-set-variables was added by Custom.

--- a/lisp/open-terminal.el
+++ b/lisp/open-terminal.el
@@ -1,0 +1,51 @@
+;;; open-terminal.el --- 外部ターミナルでコマンドを起動するユーティリティ -*- lexical-binding: t; -*-
+
+;; Author: KaitoMuraoka <https://github.com/KaitoMuraoka>
+;; Version: 0.1.0
+;; Package-Requires: ((emacs "27.1"))
+;; Keywords: terminals, tools
+;; URL: https://github.com/KaitoMuraoka/emacs-open-terminal
+
+;;; Commentary:
+;; 外部ターミナル（WezTerm / Ghostty / Terminal.app）で任意のコマンドを
+;; 非同期実行するユーティリティ関数を提供する。
+
+;;; Code:
+
+(defun my/open-terminal-with-command (dir command)
+  "DIR をカレントディレクトリとして COMMAND を外部ターミナルで非同期実行する。
+優先順位: WezTerm → Ghostty → Terminal.app"
+  (let ((wezterm "/opt/homebrew/bin/wezterm"))
+    (cond
+     ;; WezTerm: CLI が利用可能
+     ((file-executable-p wezterm)
+      (start-process "claude-terminal" nil
+                     wezterm "start" "--cwd" dir "--" "bash" "-c" command)
+      (start-process "claude-terminal-focus" nil
+                     "osascript" "-e" "tell application \"WezTerm\" to activate"))
+     ;; Ghostty: osascript で新規ウィンドウを開いてコマンドを送る
+     ((file-directory-p "~/Applications/Ghostty.app")
+      (start-process "claude-terminal" nil
+                     "osascript" "-e"
+                     (format "tell application \"Ghostty\" to activate")))
+     ;; Terminal.app: フォールバック
+     (t
+      (start-process "claude-terminal" nil
+                     "osascript" "-e"
+                     (format "tell application \"Terminal\" to do script \"cd %s && %s\""
+                             (shell-quote-argument dir) command))
+      (start-process "claude-terminal-focus" nil
+                     "osascript" "-e" "tell application \"Terminal\" to activate")))))
+
+(defun open-claude-code ()
+  "現在のバッファのディレクトリで Claude Code を外部ターミナルで開く。"
+  (interactive)
+  (let ((dir (expand-file-name default-directory)))
+    (my/open-terminal-with-command dir "claude")
+    (message "Claude Code を起動しました: %s" dir)))
+
+(global-set-key (kbd "C-c A t") #'open-claude-code)
+
+(provide 'open-terminal)
+
+;;; open-terminal.el ends here


### PR DESCRIPTION
## 変更内容

- `lisp/open-terminal.el` を新規追加
  - 外部ターミナル（WezTerm / Ghostty / Terminal.app）で任意のコマンドを非同期実行するユーティリティ関数 `my/open-terminal-with-command` を実装
  - 現在のバッファのディレクトリで Claude Code を起動するインタラクティブ関数 `open-claude-code` を追加
  - `C-c A t` キーバインドで `open-claude-code` を呼び出せるように設定
  - ターミナル起動後、対象アプリにフォーカスが移るよう `osascript` で `activate` を実行
- `init.el` に `lisp/` を `load-path` に追加し、`open-terminal` を `require` するコードを追加

## 変更理由

Emacs から直接 Claude Code を外部ターミナルで素早く起動できるようにするため。`C-c A t` のキーバインド一発で現在の作業ディレクトリを引き継いだターミナルを開けるようにした。

## 備考

- ターミナルの優先順位は WezTerm → Ghostty → Terminal.app の順
- Ghostty については現時点でコマンド送信の実装が未完のため、アプリをアクティブにするのみ
- WezTerm の CLI パスは `/opt/homebrew/bin/wezterm` をハードコードしているため、インストール先が異なる場合は変更が必要