### PR TITLE
コンソール環境でのみ背景を透明化し、メニューバーと行番号の背景を調整

### DIFF
--- a/init.el
+++ b/init.el
@@ -122,6 +122,14 @@
 ;;; 外観（透明化・ガラス効果）
 ;;; ============================================================
 
+;; コンソール時だけ背景を透明（ターミナルの背景をそのまま使う）
+(unless (display-graphic-p)
+  (set-face-background 'default "unspecified-bg"))
+;;メニューバーを非表示
+(menu-bar-mode -1)
+;; 行番号を透明にする
+(set-face-background 'line-number "unspecified-bg")
+
 ;;; ============================================================
 ;;; eat（Emulate A Terminal）
 ;;; vterm より軽量な純 Emacs Lisp 製ターミナルエミュレータ


### PR DESCRIPTION
## 変更内容

コンソール（非GUIフレーム）環境でのみ、背景色をターミナルの背景に合わせるよう設定を追加した。

- `default` フェイスの背景を `unspecified-bg` に設定（コンソール時のみ）
- メニューバーを非表示に設定
- `line-number` フェイスの背景を `unspecified-bg` に設定し、行番号エリアをターミナル背景と統一

## 変更理由

コンソールモードで Emacs を起動した際、背景色がターミナルの設定と一致せず見た目が崩れる問題があった。`unless (display-graphic-p)` で GUI 環境に影響を与えることなく、コンソール専用の背景透過設定を適用することで、ターミナルの背景をそのまま活かした外観を実現する。

## 備考

- GUI（グラフィカルフレーム）では `display-graphic-p` が `t` を返すため、この設定は適用されない
- `unspecified-bg` は「背景色を指定しない（ターミナルの背景をそのまま使用する）」という Emacs の特殊値