### PR TITLE
TUI環境でxterm-mouse-modeを有効化してターミナルのマウスイベントを受け取れるように設定

### DIFF
--- a/init.el
+++ b/init.el
@@ -164,7 +164,9 @@
 
 ;; コンソール時だけ背景を透明（ターミナルの背景をそのまま使う）
 (unless (display-graphic-p)
-  (set-face-background 'default "unspecified-bg"))
+  (set-face-background 'default "unspecified-bg")
+  ;; TUI時はターミナルのマウスイベントを受け取る
+  (xterm-mouse-mode 1))
 ;;メニューバーを非表示
 (menu-bar-mode -1)
 ;; 行番号を透明にする


### PR DESCRIPTION
## 変更内容

TUI（テキストユーザーインターフェース）環境で `xterm-mouse-mode` を有効化した。

コンソール起動時（`display-graphic-p` が偽の場合）に `(xterm-mouse-mode 1)` を呼び出すことで、ターミナル上でもマウス操作を受け付けるようにした。

## 変更理由

TUI環境ではデフォルトでマウスイベントがEmacsに渡されないため、クリックやスクロールなどのマウス操作が機能しなかった。`xterm-mouse-mode` を有効化することで、対応ターミナル上でマウス入力をEmacsが処理できるようになる。

## 備考

- GUI環境（`display-graphic-p` が真）では従来通り変更なし
- `xterm-mouse-mode` はxterm互換のエスケープシーケンスを利用するため、対応していないターミナルエミュレータでは効果がない場合がある