### PR TITLE
Setup wxxp(Webkit)

### DIFF
--- a/init.el
+++ b/init.el
@@ -244,6 +244,7 @@
 ;;; org-mode
 ;;; ============================================================
 (use-package org
+  :straight nil   ; line 32 で built-in として登録済みのため straight 管理不要
   :hook (org-mode . visual-line-mode)
   :custom
   (org-directory "~/org/")
@@ -390,7 +391,6 @@
               ("C-c l f" . eglot-format-buffer)     ; フォーマット
               ("M-."     . xref-find-definitions)   ; 定義へジャンプ
               ("M-,"     . xref-pop-marker-stack))) ; ジャンプ前に戻る
-
 ;;; ============================================================
 ;;; 言語モード
 ;;; ============================================================
@@ -585,13 +585,47 @@ DO NOT add an explanation or a body. Output ONLY the commit summary line."))
 ;;; 自作関数
 ;;; ============================================================
 
+(defun my/browse-url (url &rest args)
+  "URLを開く。GUIかつ xwidget が使える場合は xwidget-webkit を使い、
+そうでなければ browse-url-default-browser へフォールバックする。"
+  (if (and (display-graphic-p)
+           (featurep 'xwidget-internal))
+      (xwidget-webkit-browse-url url)
+    (apply #'browse-url-default-browser url args)))
+
 (defun my/post-to-x (text)
   "Intent URL を Emacs 内のWebKitブラウザで開く"
   (interactive
    (list (read-string "Xに投稿: ")))
   (let* ((encoded (url-hexify-string text))
          (url (concat "https://x.com/intent/tweet?text=" encoded)))
-    (browse-url url)))
+    (my/browse-url url)))
+
+;;; ============================================================
+;;; xwidget-webkit（WebKitブラウザ）設定
+;;; GUI Emacs かつ xwidget サポート付きでビルドされた場合のみ有効
+;;; ============================================================
+
+(use-package xwidget
+  :ensure nil
+  :if (and (display-graphic-p) (featurep 'xwidget-internal))
+
+  :custom
+  ;; browse-url の既定ブラウザを xwidget-webkit に設定（GUIのみ）
+  ;; 理由: TUI環境では xwidget は使えないため、:if ガードと組み合わせる
+  (browse-url-browser-function #'xwidget-webkit-browse-url)
+
+  :bind (:map xwidget-webkit-mode-map
+              ;; C-l : 新しい URL を入力して開く
+              ("C-l"       . xwidget-webkit-browse-url)
+              ;; C-c C-l : 現在の URL をエコーエリアに表示
+              ("C-c C-l"   . xwidget-webkit-current-url)
+              ;; TAB / S-TAB / RET : WebKit ネイティブのキーを通過させる
+              ;; 理由: xwidget-webkit にはリンク移動の Emacs 関数が存在せず、
+              ;;       WebKit が TAB/RET によるリンク・フォーム移動を内部処理する
+              ("TAB"       . xwidget-webkit-pass-command-event)
+              ("<backtab>" . xwidget-webkit-pass-command-event)
+              ("RET"       . xwidget-webkit-pass-command-event)))
 
 ;;; ============================================================
 ;;; よく使うキーバインド

--- a/init.el
+++ b/init.el
@@ -618,9 +618,16 @@ DO NOT add an explanation or a body. Output ONLY the commit summary line."))
   ;; リンク選択の補完システム: default = completing-read を使い vertico+orderless と連携する
   (xwwp-follow-link-completion-system 'default)
 
+  :config
+  ;; xwwp-ace: ace-jump スタイルでページ内のインタラクティブ要素を選択する
+  ;; 理由: xwwp-ace は xwwp のサブモジュールのため明示的に require が必要
+  (require 'xwwp-ace)
+
   :bind (:map xwidget-webkit-mode-map
               ;; v : ページ内リンクを補完選択して開く（xwwp の主要機能）
               ("v"     . xwwp-follow-link)
+              ;; f : ace-jump スタイルでページ内の要素にラベルを表示して選択
+              ("f"     . xwwp-ace-toggle)
               ;; C-l : DWIM URL 入力（URL・検索ワードを受け付けるラッパー）
               ("C-l"   . xwwp)
               ;; C-c C-l : 現在の URL をエコーエリアに表示

--- a/init.el
+++ b/init.el
@@ -598,6 +598,10 @@ DO NOT add an explanation or a body. Output ONLY the commit summary line."))
 ;;; https://github.com/canatella/xwwp
 ;;; ============================================================
 
+;; ctable: xwwp の依存パッケージ（テーブル描画ライブラリ）
+(use-package ctable
+  :straight (:type git :host github :repo "kiwanami/emacs-ctable"))
+
 (use-package xwwp
   :straight (:type git :host github :repo "kchanqvq/xwwp" :files ("*.el"))
   :if (and (display-graphic-p) (featurep 'xwidget-internal))

--- a/init.el
+++ b/init.el
@@ -188,26 +188,17 @@
 ;;; ============================================================
 ;;; kuro（Rust バックエンドのターミナルエミュレータ）
 ;;; ============================================================
+;; MELPA 公開後に以下でインストール予定:
+;;   M-x package-install RET kuro RET
+;; 現在は straight でのインストール時にサブモジュールエラーが発生するため無効化中
 
-(use-package kuro
-  :straight (:type git :host github :repo "takeokunn/kuro"
-             :files ("emacs-lisp/*.el")
-             :pre-build (("make" "build") ("make" "install")))
-  ;; kuro-create の autoload は kuro-lifecycle.el のみをロードするが、
-  ;; kuro--ensure-module-loaded は kuro-module.el にあり kuro.el 経由でしか require されない。
-  ;; :demand t で起動時に kuro.el ごとロードして依存を解決する。
-  :demand t
-
-  :hook
-  ;; kuro バッファの表示をターミナルに近づける
-  ;; 理由: 行番号・ハイライトがあるとターミナル表示が崩れるため無効化
-  (kuro-mode . (lambda ()
-                 (display-line-numbers-mode -1)
-                 (hl-line-mode -1)))
-
-  :bind
-  ;; C-c v k : 新しい kuro ターミナルを開く
-  ("C-c v k" . kuro-create))
+;; (use-package kuro
+;;   :hook
+;;   (kuro-mode . (lambda ()
+;;                  (display-line-numbers-mode -1)
+;;                  (hl-line-mode -1)))
+;;   :bind
+;;   ("C-c v k" . kuro-create))
 
 ;;; ============================================================
 ;;; claude-code-ide

--- a/init.el
+++ b/init.el
@@ -610,8 +610,8 @@ DO NOT add an explanation or a body. Output ONLY the commit summary line."))
   (xwwp-follow-link-completion-system 'default)
 
   :config
-  ;; xwwp-ace: ace-jump スタイルでページ内のインタラクティブ要素を選択する
-  ;; 理由: xwwp-ace は xwwp のサブモジュールのため明示的に require が必要
+  ;; xwwp のサブモジュールは autoload されないため明示的に require する
+  (require 'xwwp-follow-link)
   (require 'xwwp-ace)
 
   :bind (:map xwidget-webkit-mode-map

--- a/init.el
+++ b/init.el
@@ -615,8 +615,8 @@ DO NOT add an explanation or a body. Output ONLY the commit summary line."))
   ;; browse-url の既定ブラウザを xwidget-webkit に設定（GUIのみ）
   ;; 理由: TUI環境では xwidget は使えないため、:if ガードと組み合わせる
   (browse-url-browser-function #'xwidget-webkit-browse-url)
-  ;; リンク選択の補完システム: completing-read を使い vertico+orderless と連携する
-  (xwwp-follow-link-completion-system 'completing-read)
+  ;; リンク選択の補完システム: default = completing-read を使い vertico+orderless と連携する
+  (xwwp-follow-link-completion-system 'default)
 
   :bind (:map xwidget-webkit-mode-map
               ;; v : ページ内リンクを補完選択して開く（xwwp の主要機能）

--- a/init.el
+++ b/init.el
@@ -608,7 +608,7 @@ DO NOT add an explanation or a body. Output ONLY the commit summary line."))
 ;;; ============================================================
 
 (use-package xwwp
-  :straight (:type git :host github :repo "canatella/xwwp")
+  :straight (:type git :host github :repo "kchanqvq/xwwp")
   :if (and (display-graphic-p) (featurep 'xwidget-internal))
 
   :custom

--- a/init.el
+++ b/init.el
@@ -602,30 +602,29 @@ DO NOT add an explanation or a body. Output ONLY the commit summary line."))
     (my/browse-url url)))
 
 ;;; ============================================================
-;;; xwidget-webkit（WebKitブラウザ）設定
+;;; xwwp（xwidget-webkit 拡張）設定
 ;;; GUI Emacs かつ xwidget サポート付きでビルドされた場合のみ有効
+;;; https://github.com/canatella/xwwp
 ;;; ============================================================
 
-(use-package xwidget
-  :ensure nil
+(use-package xwwp
+  :straight (:type git :host github :repo "canatella/xwwp")
   :if (and (display-graphic-p) (featurep 'xwidget-internal))
 
   :custom
   ;; browse-url の既定ブラウザを xwidget-webkit に設定（GUIのみ）
   ;; 理由: TUI環境では xwidget は使えないため、:if ガードと組み合わせる
   (browse-url-browser-function #'xwidget-webkit-browse-url)
+  ;; リンク選択の補完システム: completing-read を使い vertico+orderless と連携する
+  (xwwp-follow-link-completion-system 'completing-read)
 
   :bind (:map xwidget-webkit-mode-map
-              ;; C-l : 新しい URL を入力して開く
-              ("C-l"       . xwidget-webkit-browse-url)
+              ;; v : ページ内リンクを補完選択して開く（xwwp の主要機能）
+              ("v"     . xwwp-follow-link)
+              ;; C-l : DWIM URL 入力（URL・検索ワードを受け付けるラッパー）
+              ("C-l"   . xwwp)
               ;; C-c C-l : 現在の URL をエコーエリアに表示
-              ("C-c C-l"   . xwidget-webkit-current-url)
-              ;; TAB / S-TAB / RET : WebKit ネイティブのキーを通過させる
-              ;; 理由: xwidget-webkit にはリンク移動の Emacs 関数が存在せず、
-              ;;       WebKit が TAB/RET によるリンク・フォーム移動を内部処理する
-              ("TAB"       . xwidget-webkit-pass-command-event)
-              ("<backtab>" . xwidget-webkit-pass-command-event)
-              ("RET"       . xwidget-webkit-pass-command-event)))
+              ("C-c C-l" . xwidget-webkit-current-url)))
 
 ;;; ============================================================
 ;;; よく使うキーバインド

--- a/init.el
+++ b/init.el
@@ -599,7 +599,7 @@ DO NOT add an explanation or a body. Output ONLY the commit summary line."))
 ;;; ============================================================
 
 (use-package xwwp
-  :straight (:type git :host github :repo "kchanqvq/xwwp")
+  :straight (:type git :host github :repo "kchanqvq/xwwp" :files ("*.el"))
   :if (and (display-graphic-p) (featurep 'xwidget-internal))
 
   :custom


### PR DESCRIPTION
この変更を導入するには、Emacs plus を使う様にしてください。

```sh
brew tap d12frosted/emacs-plus
brew install emacs-plus@30 --with-xwidgets

インストール後：
# Emacs.app を Applications に配置
ln -sf "$(brew --prefix)/opt/emacs-plus@30/Emacs.app" ~/Applications/Emacs.app
```



- **feat(emacs): xwidget-webkit ブラウザサポートを追加**
- **feat(emacs): xwidget をxwwpに置き換えてリンク補完機能を追加**
- **fix(xwwp): completion-system を completing-read から default に修正**
- **feat(xwwp): フォーク元を canatella/xwwp から kchanqvq/xwwp に変更**
- **feat(xwwp): xwwp-ace-toggle を f キーに追加**
- **fix(kuro): MELPA 未公開のため straight インストールを無効化**
- **fix(xwwp): :files ("*.el") を追加して xwwp-ace.el を含める**
- **fix(xwwp): xwwp-follow-link を明示的に require して v キーを修正**
- **fix(xwwp): 依存パッケージ ctable を追加**
