### PR TITLE
feat: vterm・agent-shell・組み込みパッケージの修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,5 +83,6 @@ public/
 flycheck_init.el
 
 .DS_Store
+*vterm*/
 straight/
 /.agent-shell/

--- a/init.el
+++ b/init.el
@@ -741,7 +741,7 @@ DO NOT add an explanation or a body. Output ONLY the commit summary line."))
 ;; 理由: ターミナル環境でバックスペースが C-h として送られることが多く、
 ;;       直感的な操作に合わせる
 ;; ヘルプは C-? で引き続き使用可能
-(global-set-key (kbd "C-h") 'delete-backward-char)
+(global-set-key "\C-h" 'delete-backward-char)
 (global-set-key (kbd "C-?") 'help-command)
 
 (custom-set-variables

--- a/init.el
+++ b/init.el
@@ -64,8 +64,10 @@
 ;; exec-path-from-shell でシェル環境を読み込む
 ;; gopls など go/bin に置かれるツールを認識させるために必要
 (use-package exec-path-from-shell
-  :if (memq window-system '(mac ns x))
   :config
+  ;; GUI/TUI を問わず実行する
+  ;; 理由: macOS は /etc/zprofile 経由で PATH を組み立てるため、
+  ;;       起動方法によらずシェルから正しい PATH を取得する必要がある
   (exec-path-from-shell-initialize))
 
 ;;; ============================================================
@@ -190,6 +192,8 @@
   :custom
   ;; ターミナル名（xterm-256color 互換）
   (eat-term-name "xterm-256color")
+  ;; ログインシェルで起動する（vterm と同様の理由）
+  (eat-shell (concat shell-file-name " -l"))
 
   :hook
   ;; eshell 内で eat を使う場合のシェル統合
@@ -609,6 +613,10 @@ DO NOT add an explanation or a body. Output ONLY the commit summary line."))
   (vterm-kill-buffer-on-exit t)
   ;; コピーモード時に C-c C-c でターミナルに戻る
   (vterm-copy-exclude-prompt t)
+  ;; ログインシェルで起動する
+  ;; 理由: Terminal.app と同様に ~/.zprofile を読み込み
+  ;;       Homebrew 等の PATH を引き継ぐため
+  (vterm-shell (concat shell-file-name " -l"))
 
   :config
   ;; vterm バッファでは行番号・hl-line を無効化

--- a/init.el
+++ b/init.el
@@ -265,7 +265,45 @@
    (claude-agent-acp . "npm install -g @zed-industries/claude-agent-acp"))
   :config
   (setq agent-shell-anthropic-authentication
-        (agent-shell-anthropic-make-authentication :login t)))
+        (agent-shell-anthropic-make-authentication :login t))
+
+  ;; agent-shell--start が呼ばれた瞬間のバッファの dir を保存する
+  ;; 理由: start 内で default-directory が書き換わる前に正しいディレクトリを確保するため
+  (defvar my/agent-shell--invoked-dir nil)
+
+  (advice-add 'agent-shell--start :before
+              (lambda (&rest _)
+                (setq my/agent-shell--invoked-dir default-directory)))
+
+  ;; Claude Code と同じパスエンコード: / と . を - に変換
+  ;; 例: /Users/foo/.bar → -Users-foo--bar
+  (defun my/agent-shell--encode-path (path)
+    (replace-regexp-in-string "[/.]" "-" (directory-file-name path)))
+
+  ;; 正しいプロジェクトルートをキャプチャ済みの dir から解決する
+  (setq agent-shell-cwd-function
+        (lambda ()
+          (let* ((dir (or my/agent-shell--invoked-dir default-directory))
+                 (proj (let ((default-directory dir))
+                         (when-let ((p (project-current nil)))
+                           (project-root p)))))
+            (or proj dir))))
+
+  ;; 保存先を ~/.claude/projects/{encoded}/agent-shell/{subdir} に変更
+  ;; 理由: Claude Code と同じディレクトリ構造に合わせる
+  (setq agent-shell-dot-subdir-function
+        (lambda (subdir)
+          (let* ((dir (or my/agent-shell--invoked-dir default-directory))
+                 (proj (let ((default-directory dir))
+                         (when-let ((p (project-current nil)))
+                           (project-root p))))
+                 (base (or proj dir))
+                 (encoded (my/agent-shell--encode-path base))
+                 (dest (expand-file-name
+                        (file-name-concat "projects" encoded "agent-shell" subdir)
+                        "~/.claude")))
+            (make-directory dest t)
+            dest))))
 
 ;;; ============================================================
 ;;; org-mode

--- a/init.el
+++ b/init.el
@@ -575,10 +575,57 @@ DO NOT add an explanation or a body. Output ONLY the commit summary line."))
 ;;; eat ターミナル キーバインド
 ;;; ============================================================
 
-;; C-c v t : 新しい eat ターミナルを開く
-(global-set-key (kbd "C-c v t") #'eat)
+;; C-c v e : 新しい eat ターミナルを開く
+(global-set-key (kbd "C-c v e") #'eat)
 ;; C-c v o : 別ウィンドウで eat を開く
 (global-set-key (kbd "C-c v o") #'eat-other-window)
+
+;;; ============================================================
+;;; vterm
+;;; ============================================================
+
+(use-package vterm
+  :custom
+  ;; スクロールバッファの最大行数
+  (vterm-max-scrollback 10000)
+  ;; プロセス終了時にバッファを自動で閉じる
+  (vterm-kill-buffer-on-exit t)
+  ;; コピーモード時に C-c C-c でターミナルに戻る
+  (vterm-copy-exclude-prompt t)
+
+  :config
+  ;; vterm バッファでは行番号・hl-line を無効化
+  (add-hook 'vterm-mode-hook
+            (lambda ()
+              (display-line-numbers-mode -1)
+              (hl-line-mode -1)))
+
+  :bind
+  ;; C-c v t : vterm を開く
+  ("C-c v t" . vterm))
+
+(use-package vterm-toggle
+  :after vterm
+  :custom
+  ;; vterm ウィンドウを下部に表示
+  (vterm-toggle-fullscreen-p nil)
+  (vterm-toggle-scope 'project)
+
+  :config
+  (add-to-list 'display-buffer-alist
+               '((lambda (buf _)
+                   (with-current-buffer buf (eq major-mode 'vterm-mode)))
+                 (display-buffer-reuse-window display-buffer-at-bottom)
+                 (reusable-frames . visible)
+                 (window-height . 0.3)))
+
+  :bind
+  ;; C-c v v : vterm をトグル（下部に表示）
+  ("C-c v v" . vterm-toggle)
+  ;; C-c v f : 次の vterm バッファへ切り替え
+  ("C-c v f" . vterm-toggle-forward)
+  ;; C-c v b : 前の vterm バッファへ切り替え
+  ("C-c v b" . vterm-toggle-backward))
 
  ;;; ============================================================
 ;;; プロジェクト管理

--- a/init.el
+++ b/init.el
@@ -31,6 +31,23 @@
 ;;       存在しないケースがあり :pre-build エラーで init.el がアボートするため
 (straight-use-package '(org :type built-in))
 
+;; project を組み込みとして扱う
+;; 理由: 依存パッケージ経由で straight が外部版をビルドすると
+;;       "Feature 'project' is now provided by a different file" エラーが発生するため
+(straight-use-package '(project :type built-in))
+
+;; flymake を組み込みとして扱う
+;; 理由: 同上。外部版との競合で起動エラーになるため
+(straight-use-package '(flymake :type built-in))
+
+;; Emacs 29 以降で組み込みになったパッケージを built-in として宣言する
+;; 理由: 依存パッケージが外部版を引き込み、起動時に
+;;       "Feature 'X' is now provided by a different file" エラーが連鎖するため
+;; transient は agent-shell が新しい API（transient--set-layout 等）を使うため
+;; built-in ではなく straight で外部版を管理する
+(dolist (pkg '(xref eldoc seq eglot jsonrpc use-package))
+  (straight-use-package `(,pkg :type built-in)))
+
 ;;; ============================================================
 ;; パッケージマネージャーの設定
 ;;; ============================================================


### PR DESCRIPTION
## Summary

- **vterm / vterm-toggle のセットアップ追加**: プロジェクトスコープでトグル可能なターミナルを導入。`C-c v t` で vterm を開き、`C-c v v` でトグル表示
- **vterm・eat をログインシェルで起動**: `~/.zprofile` を読み込み、Homebrew などの PATH を正しく引き継ぐよう修正
- **組み込みパッケージと straight の競合解消**: `project`・`flymake`・`xref` 等を `:type built-in` として宣言し、起動時の `Feature 'X' is now provided by a different file` エラーを解消
- **agent-shell の履歴を `~/.claude/projects/` 配下に保存**: Claude Code と同じディレクトリ構造に揃える。起動時のディレクトリからプロジェクトルートを解決し、パスエンコードして保存先を決定
- **exec-path-from-shell を GUI/TUI 問わず実行**: macOS の PATH 問題に対応

## Test plan

- [ ] Emacs 起動時にエラーが出ないことを確認
- [ ] `C-c v t` で vterm が開くことを確認
- [ ] `C-c v v` で vterm がトグル表示されることを確認
- [ ] agent-shell 起動後、`~/.claude/projects/{encoded}/agent-shell/` に履歴が保存されることを確認
- [ ] vterm・eat がログインシェルとして起動し、Homebrew の PATH が通っていることを確認