### PR TITLE
fix: TUI設定の修正とターミナルバックエンドをvtermに変更

### DIFF
--- a/init.el
+++ b/init.el
@@ -232,8 +232,8 @@
   :straight (:type git :host github :repo "manzaltu/claude-code-ide.el")
 
   :custom
-  ;; ターミナルバックエンド: eat
-  (claude-code-ide-terminal-backend 'eat)
+  ;; ターミナルバックエンド: vterm
+  (claude-code-ide-terminal-backend 'vterm)
   ;; Claude ウィンドウを右側に表示（'right / 'left / 'bottom / 'top）
   (claude-code-ide-window-side 'right)
   ;; ediff を使ったファイル差分表示を有効化

--- a/init.el
+++ b/init.el
@@ -171,14 +171,8 @@
 ;; GUI の外観
 (load-theme 'modus-vivendi t)
 
-;; コンソール時だけ背景を透明（ターミナルの背景をそのまま使う）
+;; TUI時はターミナルのマウスイベントを受け取る
 (unless (display-graphic-p)
-  (set-face-background 'default "unspecified-bg")
-  ;; 行番号の背景をターミナル背景に合わせて透明にする
-  ;; 理由: TUIでは行番号エリアにテーマの背景色が残り浮いて見えるため
-  (set-face-background 'line-number "unspecified-bg")
-  (set-face-background 'line-number-current-line "unspecified-bg")
-  ;; TUI時はターミナルのマウスイベントを受け取る
   (xterm-mouse-mode 1))
 
 ;;; ============================================================


### PR DESCRIPTION
## Summary

- TUI時の背景透過設定（`set-face-background` で `unspecified-bg` を設定する処理）を削除
- `claude-code-ide` のターミナルバックエンドを `eat` から `vterm` に変更

## Changes

### `init.el`
- TUI時の背景透過設定を削除（`default`、`line-number`、`line-number-current-line` の背景色設定）
- `unless (display-graphic-p)` ブロックはマウスイベント受け取りのみに簡素化
- `claude-code-ide-terminal-backend` を `'eat` から `'vterm` に変更

## Test plan

- [ ] TUI（ターミナル）でEmacsを起動し、表示が正常であることを確認
- [ ] `claude-code-ide` がvtermバックエンドで正常に動作することを確認
- [ ] GUIモードでの動作に影響がないことを確認