### PR TITLE
org-modeの基本設定とタスク管理機能を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ flycheck_init.el
 *vterm*/
 straight/
 /.agent-shell/
+org-clock-save.el

--- a/init.el
+++ b/init.el
@@ -106,6 +106,10 @@
 ;; 自動保存ファイル（#file.txt#）も作らない
 (setq auto-save-default nil)
 
+;; ロックファイル（.#file.txt）を作らない
+;; 理由: macOS でロック/アンロック時に "Invalid argument" 警告が出るため
+(setq create-lockfiles nil)
+
 ;; フォーカスが外れたら全ファイルバッファを保存する
 ;; 理由: 他アプリに切り替えた瞬間に変更が保存され、データ損失を防ぐ
 (add-hook 'focus-out-hook
@@ -595,6 +599,31 @@
   (let* ((encoded (url-hexify-string text))
          (url (concat "https://x.com/intent/tweet?text=" encoded)))
     (browse-url url)))
+
+;;; ============================================================
+;;; org-mode
+;;; ============================================================
+
+(use-package org
+  :straight (:type built-in)
+
+  :custom
+  (org-directory "~/org")
+  (org-default-notes-file "~/org/notes.org")
+  (org-todo-keywords '((sequence "TODO" "DOING" "|" "DONE")))
+  (org-clock-into-drawer t)
+  (org-clock-persist t)
+  (org-clock-persist-query-resume nil)
+
+  :config
+  (org-clock-persistence-insinuate)
+
+  :bind
+  ("C-c a"       . org-agenda)
+  ("C-c c"       . org-capture)
+  ("C-c C-x C-i" . org-clock-in)
+  ("C-c C-x C-o" . org-clock-out)
+  ("C-c C-x C-j" . org-clock-goto))
 
 ;;; ============================================================
 ;;; よく使うキーバインド

--- a/init.el
+++ b/init.el
@@ -614,6 +614,11 @@
   (org-clock-into-drawer t)
   (org-clock-persist t)
   (org-clock-persist-query-resume nil)
+  (org-capture-templates
+   '(("t" "タスク" entry
+      (file org-default-notes-file)
+      "* TODO %?\n"
+      :empty-lines 1)))
 
   :config
   (org-clock-persistence-insinuate)


### PR DESCRIPTION
## 変更内容

- **org-mode の基本設定を追加**
  - `org-directory` / `org-default-notes-file` の設定
  - TODO ステートを `TODO → DOING → DONE` の3段階に定義
  - `org-clock` による作業時間の記録・永続化を有効化
  - `org-capture` のテンプレートにタスク登録用エントリを追加
  - `C-c a`（agenda）・`C-c c`（capture）・clock 操作のキーバインドを設定

- **org-clock-save.el を .gitignore に追加**
  - org-clock の永続化ファイルをリポジトリ管理対象外に変更

- **ロックファイルの生成を無効化**（`create-lockfiles nil`）
  - macOS でロック/アンロック時に発生する `"Invalid argument"` 警告を抑制

## 変更理由

Emacs で日々のタスク管理・時間記録を行うために org-mode を導入した。最低限の設定として、タスクのキャプチャ・TODO 状態管理・クロック機能を組み込んでいる。

org-clock の永続化ファイル（`org-clock-save.el`）はマシン固有の状態を持つため、gitignore に追加して誤コミットを防ぐ。

ロックファイルについては、macOS 環境固有の警告が頻発していたため、既存の自動保存無効化設定と合わせて無効化した。

## 備考

- `org-directory` は `~/org` を前提としており、ディレクトリおよび `~/org/notes.org` は事前に手動で作成する必要がある
- org-agenda・clock 機能はキーバインドのみ設定済み。アジェンダファイルの登録（`org-agenda-files`）は今後の設定で追加予定