### PR TITLE
デフォルトで行の折り返しを有効化する

### DIFF
--- a/init.el
+++ b/init.el
@@ -148,6 +148,9 @@
 ;; ペースト前にクリップボードの内容をkill-ringに保存する
 (setq save-interprogram-paste-before-kill t)
 
+;;折り返しをデフォルトにする
+(setq-default truncate-lines nil)
+
 ;; TUIモード（ターミナルエミュレータ）でのクリップボード連携
 ;; 理由: select-enable-clipboard はGUI専用のため、
 ;;       TUI環境では pbcopy/pbpaste 経由でOSクリップボードと接続する


### PR DESCRIPTION
  truncate-lines を nil にすることで、行の折り返しをデフォルトで有効にしています。通常 
  Emacs はウィンドウ幅を超えた行を折り返さず横スクロールしますが、この設定でウィンドウ
  幅に合わせて折り返すようになります。 