### PR TITLE
refactor(base): kill-ring とシステムクリップボードの連携を削除

### DIFF
--- a/modules/mk-base.el
+++ b/modules/mk-base.el
@@ -68,32 +68,9 @@
 ;; ファイル末尾に改行を自動挿入
 (setq require-final-newline t)
 
-;; ペースト前にクリップボードの内容をkill-ringに保存する
-(setq save-interprogram-paste-before-kill t)
-
 ;;折り返しをデフォルトにする
 (setq-default truncate-lines nil)
 (setq-default org-startup-truncated nil);; org-mode ではデフォルト折り返ししないので
-
-;; クリップボードをOSと共有する（コピー・ペースト両方向）
-(setq select-enable-clipboard t)
-;; TUIモード（ターミナルエミュレータ）でのクリップボード連携
-;; 理由: select-enable-clipboard はGUI専用のため、
-;;       TUI環境では pbcopy/pbpaste 経由でOSクリップボードと接続する
-;; call-process-region を使って同期実行することで、C-w / M-w 後に
-;; 確実にOSクリップボードへ反映される
-(unless (display-graphic-p)
-  (setq interprogram-cut-function
-        (lambda (text)
-          ;; kill/copy 時に pbcopy へテキストを同期送信する
-          (with-temp-buffer
-            (insert text)
-            (call-process-region (point-min) (point-max) "pbcopy"))))
-  (setq interprogram-paste-function
-        (lambda ()
-          ;; yank 時に pbpaste からテキストを受け取る
-          (let ((result (shell-command-to-string "pbpaste")))
-            (unless (string-empty-p result) result)))))
 
 
 (setq explicit-shell-file-name "/bin/zsh")

--- a/modules/mk-view.el
+++ b/modules/mk-view.el
@@ -16,6 +16,13 @@
   :straight (:host github :repo "Greduan/emacs-theme-gruvbox"))
 (load-theme 'gruvbox-dark-medium t)
 
+;; TUI 時はターミナルの背景色に準拠（テーマ再適用時も自動で上書きを防ぐ）
+(defun mk/tui-transparent-bg (&rest _)
+  (unless (display-graphic-p)
+    (set-face-attribute 'default nil :background 'unspecified)))
+(add-hook 'enable-theme-functions #'mk/tui-transparent-bg)
+(mk/tui-transparent-bg)
+
 ;; TUI時はターミナルのマウスイベントを受け取る
 (unless (display-graphic-p)
   (xterm-mouse-mode 1))

--- a/modules/mk-view.el
+++ b/modules/mk-view.el
@@ -18,6 +18,7 @@
 
 ;; TUI時はターミナルのマウスイベントを受け取る
 (unless (display-graphic-p)
+  (load-theme 'modus-vivendi t)
   (set-face-background 'default "unspecified-bg")
   (set-face-background 'line-number "unspecified-bg")
   (set-face-background 'line-number-current-line "unspecified-bg")

--- a/modules/mk-view.el
+++ b/modules/mk-view.el
@@ -16,15 +16,11 @@
   :straight (:host github :repo "Greduan/emacs-theme-gruvbox"))
 (load-theme 'gruvbox-dark-medium t)
 
-;; TUI 時はターミナルの背景色に準拠（テーマ再適用時も自動で上書きを防ぐ）
-(defun mk/tui-transparent-bg (&rest _)
-  (unless (display-graphic-p)
-    (set-face-attribute 'default nil :background 'unspecified)))
-(add-hook 'enable-theme-functions #'mk/tui-transparent-bg)
-(mk/tui-transparent-bg)
-
 ;; TUI時はターミナルのマウスイベントを受け取る
 (unless (display-graphic-p)
+  (set-face-background 'default "unspecified-bg")
+  (set-face-background 'line-number "unspecified-bg")
+  (set-face-background 'line-number-current-line "unspecified-bg")
   (xterm-mouse-mode 1))
 
 ;; メニューバーを非表示


### PR DESCRIPTION
C-k などのカット操作でテキストが OS クリップボードへ書き込まれないよう、
select-enable-clipboard / save-interprogram-paste-before-kill および
TUI 用 pbcopy/pbpaste の interprogram-*-function 設定を削除する。
