### PR TITLE
claude-code と ghostel のセットアップを追加

### DIFF
--- a/ghostel-zsh
+++ b/ghostel-zsh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec -a -zsh /bin/zsh

--- a/init.el
+++ b/init.el
@@ -61,6 +61,7 @@
 (require 'mk-eat)
 (require 'mk-vterm)
 (require 'mk-claude-code-ide)
+(require 'mk-claude-code)
 (require 'mk-agent-shell)
 (require 'mk-git)
 (require 'mk-dirvish)

--- a/init.el
+++ b/init.el
@@ -60,6 +60,7 @@
 ;;(require 'mk-evil)
 (require 'mk-eat)
 (require 'mk-vterm)
+(require 'mk-ghostel)
 (require 'mk-claude-code-ide)
 (require 'mk-claude-code)
 (require 'mk-agent-shell)

--- a/modules/mk-claude-code-ide.el
+++ b/modules/mk-claude-code-ide.el
@@ -7,7 +7,7 @@
 
   :custom
   ;; ターミナルバックエンド: ghostel
-  (claude-code-ide-terminal-backend 'ghostel)
+  (claude-code-ide-terminal-backend 'vterm)
   ;; Claude ウィンドウを右側に表示（'right / 'left / 'bottom / 'top）
   (claude-code-ide-window-side 'right)
   ;; ediff を使ったファイル差分表示を有効化

--- a/modules/mk-claude-code-ide.el
+++ b/modules/mk-claude-code-ide.el
@@ -6,8 +6,8 @@
   :straight (:type git :host github :repo "manzaltu/claude-code-ide.el")
 
   :custom
-  ;; ターミナルバックエンド: vterm
-  (claude-code-ide-terminal-backend 'vterm)
+  ;; ターミナルバックエンド: ghostel
+  (claude-code-ide-terminal-backend 'ghostel)
   ;; Claude ウィンドウを右側に表示（'right / 'left / 'bottom / 'top）
   (claude-code-ide-window-side 'right)
   ;; ediff を使ったファイル差分表示を有効化

--- a/modules/mk-claude-code.el
+++ b/modules/mk-claude-code.el
@@ -1,16 +1,20 @@
+(use-package websocket
+  :straight t)
+
+(use-package monet
+  :straight (:type git :host github :repo "stevemolitor/monet" :branch "main" :depth 1)
+  :config
+  (monet-mode 1))
+
 (use-package claude-code
   :straight (:type git :host github :repo "stevemolitor/claude-code.el" :branch "main" :depth 1
                    :files ("*.el" (:exclude "images/*")))
   :bind-keymap
-  ("C-c c" . claude-code-command-map) ;; or your preferred key
-  ;; Optionally define a repeat map so that "M" will cycle thru Claude auto-accept/plan/confirm modes after invoking claude-code-cycle-mode / C-c M.
+  ("C-c a" . claude-code-command-map)
   :bind
   (:repeat-map my-claude-code-map ("M" . claude-code-cycle-mode))
   :config
-  ;; optional IDE integration with Monet
   (add-hook 'claude-code-process-environment-functions #'monet-start-server-function)
-  (monet-mode 1)
-
   (claude-code-mode))
 
 (provide 'mk-claude-code)

--- a/modules/mk-claude-code.el
+++ b/modules/mk-claude-code.el
@@ -1,0 +1,16 @@
+(use-package claude-code
+  :straight (:type git :host github :repo "stevemolitor/claude-code.el" :branch "main" :depth 1
+                   :files ("*.el" (:exclude "images/*")))
+  :bind-keymap
+  ("C-c c" . claude-code-command-map) ;; or your preferred key
+  ;; Optionally define a repeat map so that "M" will cycle thru Claude auto-accept/plan/confirm modes after invoking claude-code-cycle-mode / C-c M.
+  :bind
+  (:repeat-map my-claude-code-map ("M" . claude-code-cycle-mode))
+  :config
+  ;; optional IDE integration with Monet
+  (add-hook 'claude-code-process-environment-functions #'monet-start-server-function)
+  (monet-mode 1)
+
+  (claude-code-mode))
+
+(provide 'mk-claude-code)

--- a/modules/mk-claude-code.el
+++ b/modules/mk-claude-code.el
@@ -9,6 +9,8 @@
 (use-package claude-code
   :straight (:type git :host github :repo "stevemolitor/claude-code.el" :branch "main" :depth 1
                    :files ("*.el" (:exclude "images/*")))
+  :custom
+  (claude-code-terminal-backend 'ghostel)
   :bind-keymap
   ("C-c a" . claude-code-command-map)
   :bind

--- a/modules/mk-claude-code.el
+++ b/modules/mk-claude-code.el
@@ -11,6 +11,11 @@
                    :files ("*.el" (:exclude "images/*")))
   :custom
   (claude-code-terminal-backend 'ghostel)
+  (claude-code-display-window-fn
+   (lambda (buffer)
+     (display-buffer buffer '((display-buffer-in-side-window)
+                              (side . right)
+                              (window-width . 90)))))
   :bind-keymap
   ("C-c a" . claude-code-command-map)
   :bind

--- a/modules/mk-ghostel.el
+++ b/modules/mk-ghostel.el
@@ -1,0 +1,49 @@
+;;; ============================================================
+;;; ghostel
+;;; ============================================================
+
+(use-package compat
+  :straight t)
+
+(use-package ghostel
+  :straight (:type git :host github :repo "dakra/ghostel" :branch "main" :depth 1
+             :files ("lisp/*.el"))
+
+  :custom
+  ;; シェルのパスのみ指定する（ghostel は引数を別途扱うため -l は不可）
+  (ghostel-shell shell-file-name)
+  ;; プロセス終了時にバッファを自動で閉じる
+  (ghostel-kill-buffer-on-exit t)
+  ;; モジュールをリポジトリディレクトリに保存する
+  ;; 理由: straight.el はリビルド時に build/ を再作成するため
+  ;;       build/ 内のモジュールが消える。repos/ は stable なので残る。
+  (ghostel-module-directory
+   (expand-file-name "straight/repos/ghostel" user-emacs-directory))
+
+  :config
+  ;; straight.el は etc/ を build/ にコピーしないため、シンボリックリンクで代替する。
+  ;; リビルド後に空の etc/ ディレクトリが作られた場合でも対応するため
+  ;; 普通のディレクトリなら削除してからリンクを張る。
+  (let* ((build-dir (file-name-directory (locate-library "ghostel")))
+         (link (expand-file-name "etc" build-dir))
+         (target (expand-file-name "straight/repos/ghostel/etc" user-emacs-directory)))
+    (unless (file-symlink-p link)
+      (when (file-directory-p link)
+        (delete-directory link))
+      (make-symbolic-link target link)))
+
+  (add-hook 'ghostel-mode-hook
+            (lambda ()
+              (display-line-numbers-mode -1)
+              (hl-line-mode -1)))
+
+  ;; project.el のプロジェクトスイッチコマンドに追加
+  (add-to-list 'project-switch-commands '(ghostel-project "Ghostel") t)
+
+  :bind
+  ;; C-c g t : ghostel を開く
+  ("C-c g t" . ghostel)
+  ;; C-c g p : プロジェクトルートで ghostel を開く
+  ("C-c g p" . ghostel-project))
+
+(provide 'mk-ghostel)

--- a/modules/mk-ghostel.el
+++ b/modules/mk-ghostel.el
@@ -10,8 +10,6 @@
              :files ("lisp/*.el"))
 
   :custom
-  ;; シェルのパスのみ指定する（ghostel は引数を別途扱うため -l は不可）
-  (ghostel-shell shell-file-name)
   ;; プロセス終了時にバッファを自動で閉じる
   (ghostel-kill-buffer-on-exit t)
   ;; モジュールをリポジトリディレクトリに保存する
@@ -21,6 +19,17 @@
    (expand-file-name "straight/repos/ghostel" user-emacs-directory))
 
   :config
+  ;; ログインシェル起動ラッパーを作成して ghostel-shell に設定する。
+  ;; 理由: ghostel-shell は引数を取らないため "-l" を直接渡せない。
+  ;;       exec -a -zsh とすることで argv[0] を "-zsh" にし、
+  ;;       zsh をログインシェルとして起動する（.zprofile も読み込まれる）。
+  ;;       スクリプト名に "zsh" を含めることで ghostel のシェル検出にも一致する。
+  (let* ((wrapper (expand-file-name "ghostel-zsh" user-emacs-directory)))
+    (with-temp-file wrapper
+      (insert "#!/bin/bash\nexec -a -zsh /bin/zsh\n"))
+    (set-file-modes wrapper #o755)
+    (setq ghostel-shell wrapper))
+
   ;; straight.el は etc/ を build/ にコピーしないため、シンボリックリンクで代替する。
   ;; リビルド後に空の etc/ ディレクトリが作られた場合でも対応するため
   ;; 普通のディレクトリなら削除してからリンクを張る。


### PR DESCRIPTION
## 概要
Ghostty ターミナルエミュレータ統合（ghostel）と claude-code パッケージの初期設定を追加。

## 変更内容
- `mk-ghostel.el` 新規作成：ghostel セットアップ（ログインシェルラッパー、etc/ シンボリックリンク対応など）
- `mk-claude-code.el` 新規作成：claude-code セットアップ（ghostel バックエンド、右側縦分割表示）
- `ghostel-zsh` 追加：ghostel 用ログインシェルラッパースクリプト
- `init.el` に `mk-ghostel`・`mk-claude-code` の require を追加
- `claude-code-ide` のターミナルバックエンドを vterm に修正（ghostel は未サポートのため）

## 確認方法
- `C-c g t` で ghostel が起動すること
- `C-c a` で claude-code が右側縦分割で開くこと
- `C-c A s` で claude-code-ide が vterm で起動すること