### PR TITLE
Retina 環境でスプラッシュ画面の Emacs ロゴが表示されない問題を修正

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(/Applications/Emacs.app/Contents/MacOS/Emacs --version)",
+      "Bash(/Applications/Emacs.app/Contents/MacOS/Emacs *)"
+    ]
+  }
+}

--- a/modules/mk-view.el
+++ b/modules/mk-view.el
@@ -33,4 +33,14 @@
 ;; ピンチジェスチャーによるフォントサイズ変更を無効化
 (global-set-key (kbd "<pinch>") 'ignore)
 
+;; splash.svg の :scale default が Retina 環境でフレーム高を超え
+;; use-fancy-splash-screens-p が nil を返す問題を修正する。
+;; SVG が描画可能な場合は常にロゴを表示するよう advice でバイパスする。
+(when (display-graphic-p)
+  (advice-add 'use-fancy-splash-screens-p :override
+              (lambda ()
+                (and (display-graphic-p)
+                     (ignore-errors
+                       (create-image (fancy-splash-image-file)))))))
+
 (provide 'mk-view)


### PR DESCRIPTION
## 概要
Retina ディスプレイ環境でスプラッシュ画面の Emacs ロゴ（SVG）が表示されない問題を修正する。

## 原因と解決方法
`use-fancy-splash-screens-p` はスプラッシュ SVG のデフォルト `:scale` がフレーム高を超える場合に `nil` を返し、ロゴ表示をスキップする。Retina 環境ではフレーム高の算出がピクセル密度の影響を受けてこの条件が成立してしまう。

advice で `use-fancy-splash-screens-p` をオーバーライドし、SVG の描画自体が可能な場合（`create-image` が成功する場合）は常に `t` を返すことで問題を回避した。

## 変更内容
- `modules/mk-view.el`: `use-fancy-splash-screens-p` を advice でオーバーライドし、SVG が描画可能な場合は常にロゴを表示するよう修正
- `.claude/settings.local.json`: Claude Code から Emacs を起動するためのパーミッション設定を追加

## 確認方法
1. Retina ディスプレイ環境で Emacs を起動する
2. スプラッシュ画面に Emacs ロゴ（SVG）が表示されることを確認する