### PR TITLE
ターミナル Emacs 用に kitty-graphics をセットアップ

### DIFF
--- a/init.el
+++ b/init.el
@@ -65,6 +65,7 @@
 (require 'mk-eat)
 (require 'mk-vterm)
 (require 'mk-ghostel)
+(require 'mk-kitty-graphics)
 (require 'mk-claude-code-ide)
 (require 'mk-claude-code)
 (require 'mk-agent-shell)

--- a/modules/mk-kitty-graphics.el
+++ b/modules/mk-kitty-graphics.el
@@ -1,0 +1,19 @@
+;;; ============================================================
+;;; kitty-graphics (terminal Emacs での画像表示)
+;;; ============================================================
+
+(use-package kitty-graphics
+  :straight (:type git :host github :repo "cashmeredev/kitty-graphics.el" :branch "master")
+  ;; GUI Emacs では不要。ターミナル接続時のみ有効化する
+  :if (not (display-graphic-p))
+
+  :custom
+  ;; auto: 起動時に Kitty / Sixel を自動判定する
+  ;; Ghostty では Kitty backend が選ばれる
+  (kitty-gfx-preferred-protocol 'auto)
+
+  :config
+  ;; global minor mode を有効化する
+  (kitty-graphics-mode 1))
+
+(provide 'mk-kitty-graphics)


### PR DESCRIPTION
## 概要

ターミナル Emacs（Ghostty / Kitty など）で画像をインライン表示できるように、
`kitty-graphics.el` を導入する。GUI Emacs では従来通り組み込みの画像表示を使うため、
ターミナル接続時のみ有効化する構成にしている。

## 変更内容

- `modules/mk-kitty-graphics.el` を新規追加
  - `cashmeredev/kitty-graphics.el` を `straight` 経由で導入
  - `:if (not (display-graphic-p))` でターミナル接続時のみ有効化
  - `kitty-gfx-preferred-protocol` を `'auto` に設定し、Kitty / Sixel を自動判定
  - `kitty-graphics-mode` を global minor mode として有効化
- `init.el` で `mk-kitty-graphics` を `require`

## 確認方法

1. Ghostty などの Kitty graphics 対応ターミナルから `emacs -nw` で起動する
2. `M-x find-file` で PNG / JPEG などの画像ファイルを開く
3. ターミナル上に画像がインライン表示されることを確認する
4. GUI Emacs（`emacs` で通常起動）では従来通り組み込みの画像表示が使われ、
   `kitty-graphics-mode` が無効であることを確認する