### PR TITLE
DDSKK をセットアップ

### DIFF
--- a/modules/mk-base.el
+++ b/modules/mk-base.el
@@ -76,11 +76,14 @@
 ;; Emacsにフォーカスが移ったとき、macOSの入力ソースをABCに強制する
 (defun my/force-ascii-input-source ()
   (start-process "input-source" nil
-                 "osascript" "-e"
-                 "tell application \"System Events\" to key code 102"))
-;; key code 102 = 英数キー
+                 "/opt/homebrew/bin/im-select"
+                 "com.apple.keylayout.ABC"))
 
-(add-hook 'focus-in-hook #'my/force-ascii-input-source)
+(defun my/after-focus-change ()
+  (when (frame-focus-state)
+    (my/force-ascii-input-source)))
+
+(add-function :after after-focus-change-function #'my/after-focus-change)
 
 ;; Setup DDSKK
 (use-package ddskk

--- a/modules/mk-base.el
+++ b/modules/mk-base.el
@@ -82,4 +82,17 @@
 
 (add-hook 'focus-in-hook #'my/force-ascii-input-source)
 
+;; Setup DDSKK
+(use-package ddskk
+  :ensure t
+  :bind ("C-x C-j" . skk-mode)
+  :custom
+  (skk-large-jisyo "~/Library/Containers/net.mtgto.inputmethod.macSKK/Data/Documents/Dictionaries/skk-jisyo.utf8")
+  (skk-large-jisyo "~/Library/Containers/net.mtgto.inputmethod.macSKK/Data/Documents/Dictionaries/SKK-JISYO.L")
+  (skk-sticky-key ";")
+  (skk-show-inline t)
+  (skk-dcomp-activate t)
+  (skk-egg-like-newline t)
+  (skk-isearch-mode-enable 'always))
+
 (provide 'mk-base)

--- a/modules/mk-base.el
+++ b/modules/mk-base.el
@@ -73,4 +73,13 @@
 (setq shell-command-switch "-ic")
 (setenv "SHELL" shell-file-name)
 
+;; Emacsにフォーカスが移ったとき、macOSの入力ソースをABCに強制する
+(defun my/force-ascii-input-source ()
+  (start-process "input-source" nil
+                 "osascript" "-e"
+                 "tell application \"System Events\" to key code 102"))
+;; key code 102 = 英数キー
+
+(add-hook 'focus-in-hook #'my/force-ascii-input-source)
+
 (provide 'mk-base)

--- a/modules/mk-view.el
+++ b/modules/mk-view.el
@@ -11,10 +11,10 @@
   (set-fontset-font t '(#x1F300 . #x1FAFF) (font-spec :family "Apple Color Emoji") nil 'prepend))
 
 ;; GUI/TUI の外観
-;;(load-theme 'modus-vivendi t)
-(use-package gruvbox-theme
-  :straight (:host github :repo "Greduan/emacs-theme-gruvbox"))
-(load-theme 'gruvbox-dark-medium t)
+(load-theme 'modus-vivendi t)
+;; (use-package gruvbox-theme
+;;   :straight (:host github :repo "Greduan/emacs-theme-gruvbox"))
+;; (load-theme 'gruvbox-dark-medium t)
 
 ;; TUI時はターミナルのマウスイベントを受け取る
 (unless (display-graphic-p)


### PR DESCRIPTION
<html><head></head><body><h1>DDSKK 基本的な使い方</h1>
<p>Emacs 内で動作する日本語入力システム（SKK）。
macOS の IME を使わず、Emacs のキーバインドと干渉しない日本語入力ができる。</p>
<h2>モード切り替え</h2>

キー | 動作
-- | --
C-x C-j | SKK のオン/オフ
C-j | かなモードに戻る
q | カナモードに切り替え
l | ASCII モードに切り替え
L (;l) | 全角英数モードに切り替え

</body></html>