### PR TITLE
Emacs を Ruby on Rails 開発環境としてセットアップ

### DIFF
--- a/init.el
+++ b/init.el
@@ -75,6 +75,7 @@
 (require 'mk-keybind)
 (require 'mk-lsp)
 (require 'mk-language-mode)
+(require 'mk-rails)
 (custom-set-variables
  ;; custom-set-variables was added by Custom.
  ;; If you edit it by hand, you could mess it up, so be careful.

--- a/modules/mk-language-mode.el
+++ b/modules/mk-language-mode.el
@@ -26,7 +26,15 @@
 ;; ERB テンプレートサポート
 ;; web-mode は HTML に埋め込まれた Ruby（<%= %>）を適切にハイライトする
 (use-package web-mode
-  :mode ("\\.erb\\'" "\\.html\\.erb\\'"))
+  :mode ("\\.erb\\'" "\\.html\\.erb\\'")
+  :custom
+  ;; 閉じタグの自動挿入を有効化（ターミナルでも効くように明示）
+  (web-mode-enable-auto-closing t)
+  ;; 自動挿入スタイル 2: 「>」で開きタグを閉じた時と「</」入力時の
+  ;;                     両方で対応する閉じタグを自動挿入する
+  (web-mode-auto-close-style 2)
+  ;; <% %> などのペア記号も自動補完
+  (web-mode-enable-auto-pairing t))
 
 ;; YAML サポート
 ;; config/database.yml など Rails の設定ファイル用

--- a/modules/mk-language-mode.el
+++ b/modules/mk-language-mode.el
@@ -11,4 +11,27 @@
   :mode ("\\.ts\\'" . typescript-mode)
   :mode ("\\.tsx\\'" . tsx-ts-mode))
 
+;; Ruby サポート
+;; ruby-ts-mode は Emacs 30 組み込みの tree-sitter ベースのモード
+;; （grammar libtree-sitter-ruby は導入済み）
+;; .rb のほか Gemfile / Rakefile などの拡張子なしファイルも対象にする
+(use-package ruby-ts-mode
+  :straight (:type built-in)
+  :mode ("\\.rb\\'" "\\.rake\\'" "\\.gemspec\\'" "\\.ru\\'"
+         "/\\(?:Gem\\|Cap\\|Guard\\|Rake\\|Brew\\|Berks\\|Vagrant\\|Pod\\)file\\'")
+  :init
+  ;; 旧 ruby-mode が呼ばれても ruby-ts-mode に置き換える
+  (add-to-list 'major-mode-remap-alist '(ruby-mode . ruby-ts-mode)))
+
+;; ERB テンプレートサポート
+;; web-mode は HTML に埋め込まれた Ruby（<%= %>）を適切にハイライトする
+(use-package web-mode
+  :mode ("\\.erb\\'" "\\.html\\.erb\\'"))
+
+;; YAML サポート
+;; config/database.yml など Rails の設定ファイル用
+;; yaml-mode は MELPA 提供で tree-sitter grammar 不要
+(use-package yaml-mode
+  :mode ("\\.ya?ml\\'"))
+
 (provide 'mk-language-mode)

--- a/modules/mk-lsp.el
+++ b/modules/mk-lsp.el
@@ -57,6 +57,31 @@
 ;; Swift, TypeScript, ELisp など主要言語のスニペットが含まれる
 (use-package yasnippet-snippets)
 
+;; cape: 複数の補完ソース(capf)を合成・拡張する
+;; eglot 単独だと出ない「スニペット・バッファ内の語」を補うために使う
+(use-package cape)
+
+;; yasnippet-capf: yasnippet スニペットを補完候補(capf)として出す
+;; これで def 等のスニペットが corfu のポップアップに出るようになる
+(use-package yasnippet-capf
+  :after (cape yasnippet))
+
+;; corfu-popupinfo: 補完候補のドキュメントをポップアップ表示（VSCode 風）
+;; corfu に同梱の拡張なので straight では取得しない
+(use-package corfu-popupinfo
+  :straight nil
+  :after corfu
+  :hook (corfu-mode . corfu-popupinfo-mode)
+  :custom
+  (corfu-popupinfo-delay '(0.4 . 0.2)))
+
+;; LSP 非接続バッファでも最低限の補完が出るよう底上げする
+;; （スニペット・バッファ内の語・ファイルパス）
+;; 末尾(t)に追加し、各モード本来の capf を優先しつつフォールバックさせる
+(add-to-list 'completion-at-point-functions #'yasnippet-capf t)
+(add-to-list 'completion-at-point-functions #'cape-dabbrev t)
+(add-to-list 'completion-at-point-functions #'cape-file t)
+
 
 ;;; ============================================================
 ;;; LSP（Language Server Protocol）設定
@@ -136,5 +161,27 @@
 (add-hook 'ruby-ts-mode-hook
           (lambda ()
             (add-hook 'before-save-hook #'mk/eglot-format-on-save nil t)))
+
+
+;;; ============================================================
+;;; eglot の補完ソース合成（VSCode 風の補完体験）
+;;; ============================================================
+
+;; eglot は有効化時に completion-at-point-functions を自分のものだけに
+;; 置き換えてしまい、yasnippet スニペットやバッファ内の語が corfu に出なくなる。
+;;
+;; ここでは eglot（LSP）を最優先にする:
+;;   - 第1要素: cape-capf-super で「LSP + スニペット」を合成
+;;     （LSP の Method 候補と def 等のスニペットを一緒に出す）
+;;   - 第2要素: cape-dabbrev は LSP が候補を返せない箇所だけのフォールバック
+;;     （第1要素が候補を返す間は Dabbrev は出ないので Method がノイズに埋もれない）
+(defun mk/eglot-capf ()
+  (setq-local completion-at-point-functions
+              (list (cape-capf-super
+                     #'eglot-completion-at-point
+                     #'yasnippet-capf)
+                    #'cape-dabbrev)))
+
+(add-hook 'eglot-managed-mode-hook #'mk/eglot-capf)
 
 (provide 'mk-lsp)

--- a/modules/mk-lsp.el
+++ b/modules/mk-lsp.el
@@ -72,7 +72,8 @@
    (typescript-mode  . eglot-ensure)
    (tsx-ts-mode      . eglot-ensure)
    (python-mode      . eglot-ensure)
-   (python-ts-mode   . eglot-ensure))
+   (python-ts-mode   . eglot-ensure)
+   (ruby-ts-mode     . eglot-ensure))
 
   :config
   ;; Swift: sourcekit-lsp を使用
@@ -91,6 +92,12 @@
   (add-to-list 'eglot-server-programs
                '((python-mode python-ts-mode) . ("jedi-language-server")))
 
+  ;; Ruby: ruby-lsp を使用（rbenv shim 経由で .ruby-version を尊重する）
+  ;; Rails 専用機能はプロジェクトの Gemfile に ruby-lsp-rails を入れると
+  ;; ruby-lsp が自動で addon として読み込む
+  (add-to-list 'eglot-server-programs
+               '(ruby-ts-mode . ("ruby-lsp")))
+
   ;; orderless との相性問題を回避するため
   ;; eglot の補完カテゴリでは orderless を優先して使用する
   (add-to-list 'completion-category-overrides
@@ -104,5 +111,23 @@
               ("C-c l f" . eglot-format-buffer)     ; フォーマット
               ("M-."     . xref-find-definitions)   ; 定義へジャンプ
               ("M-,"     . xref-pop-marker-stack))) ; ジャンプ前に戻る
+
+
+;;; ============================================================
+;;; 保存時の自動フォーマット
+;;; ============================================================
+
+;; eglot が管理しているバッファのみフォーマットする
+;; 理由: LSP 未接続のときに eglot-format-buffer を呼ぶとエラーになるため
+(defun mk/eglot-format-on-save ()
+  "eglot 管理下のバッファを保存前にフォーマットする。"
+  (when (bound-and-true-p eglot--managed-mode)
+    (eglot-format-buffer)))
+
+;; Ruby: 保存時に ruby-lsp（RuboCop）で自動整形する
+;; 手動整形は引き続き C-c l f が使える
+(add-hook 'ruby-ts-mode-hook
+          (lambda ()
+            (add-hook 'before-save-hook #'mk/eglot-format-on-save nil t)))
 
 (provide 'mk-lsp)

--- a/modules/mk-lsp.el
+++ b/modules/mk-lsp.el
@@ -73,7 +73,8 @@
    (tsx-ts-mode      . eglot-ensure)
    (python-mode      . eglot-ensure)
    (python-ts-mode   . eglot-ensure)
-   (ruby-ts-mode     . eglot-ensure))
+   (ruby-ts-mode     . eglot-ensure)
+   (web-mode         . eglot-ensure))
 
   :config
   ;; Swift: sourcekit-lsp を使用
@@ -97,6 +98,12 @@
   ;; ruby-lsp が自動で addon として読み込む
   (add-to-list 'eglot-server-programs
                '(ruby-ts-mode . ("ruby-lsp")))
+
+  ;; HTML/ERB: vscode-html-language-server を使用
+  ;; web-mode で HTML タグ・属性の補完を corfu に出すため
+  ;; インストール: npm install -g vscode-langservers-extracted
+  (add-to-list 'eglot-server-programs
+               '(web-mode . ("vscode-html-language-server" "--stdio")))
 
   ;; orderless との相性問題を回避するため
   ;; eglot の補完カテゴリでは orderless を優先して使用する

--- a/modules/mk-org.el
+++ b/modules/mk-org.el
@@ -2,7 +2,7 @@
 ;;; org-mode
 ;;; ============================================================
 (defconst org-icloud-path
-  "/Users/kaito.muraoka/Library/Mobile Documents/com~apple~CloudDocs/org/")
+  "~/Library/Mobile Documents/com~apple~CloudDocs/org/")
 (global-set-key (kbd "C-c o") (lambda () (interactive) (dired org-icloud-path)))
 (use-package org
   :straight (:type built-in)

--- a/modules/mk-rails.el
+++ b/modules/mk-rails.el
@@ -1,0 +1,62 @@
+;; -*- lexical-binding: t; -*-
+
+;;; ============================================================
+;;; Ruby / Rails 開発支援
+;;; ============================================================
+
+;; inf-ruby: Ruby / Rails の REPL（irb / rails console）を Emacs 内で動かす
+;; inf-ruby-console-auto はプロジェクト種別を自動判定して
+;; rails console などの適切なコンソールを起動する
+(use-package inf-ruby
+  :hook
+  ;; ruby-ts-mode で C-c C-s（送信）などの inf-ruby マイナーモードを有効化
+  (ruby-ts-mode . inf-ruby-minor-mode))
+
+
+;;; ============================================================
+;;; プロジェクト操作・Rails ナビゲーション
+;;; ============================================================
+
+;; projectile: プロジェクト単位の操作（projectile-rails の前提）
+;; 注意: デフォルトプレフィックス C-c p は project.el の C-c p f/b と
+;;       衝突するため、projectile 側は C-c j に逃がす
+(use-package projectile
+  :init
+  (projectile-mode +1)
+  :bind (:map projectile-mode-map
+              ("C-c j" . projectile-command-map)))
+
+;; projectile-rails: モデル↔ビュー↔コントローラ間ジャンプ、
+;; generator / rake / console / dbconsole などを一通り提供する
+;; コマンドマップは C-c r プレフィックスに割り当てる
+;; 例: C-c r m（model）/ C-c r c（controller）/ C-c r v（view）
+;;     C-c r g（generate）/ C-c r r（rake）/ C-c r R（routes）
+(use-package projectile-rails
+  :after projectile
+  :init
+  (projectile-rails-global-mode)
+  :bind (:map projectile-rails-mode-map
+              ("C-c r" . projectile-rails-command-map)))
+
+
+;;; ============================================================
+;;; テスト（RSpec）
+;;; ============================================================
+
+;; rspec-mode: spec の実行・再実行をバッファから行う
+;; 例: C-c , v（verify file）/ C-c , s（verify single）/ C-c , r（rerun）
+(use-package rspec-mode
+  :hook (ruby-ts-mode . rspec-mode)
+  :custom
+  ;; Gemfile があれば bundle exec 経由で rspec を実行する
+  (rspec-use-bundler-when-possible t))
+
+
+;;; ============================================================
+;;; Bundler
+;;; ============================================================
+
+;; bundler: Gemfile 操作（bundle-install / bundle-open / bundle-update など）
+(use-package bundler)
+
+(provide 'mk-rails)


### PR DESCRIPTION
## 概要

Emacs で Ruby on Rails 開発を行うための環境を整備する。既存の eglot + corfu + straight.el の構成に揃え、Ruby/ERB/YAML のモードと LSP、Rails 専用ツールを追加する。

## 変更内容

- **言語モード追加**（`mk-language-mode.el`）
  - `ruby-ts-mode`（Emacs 30 組み込み、tree-sitter）を `.rb` / Gemfile / Rakefile 等に割り当て
  - `web-mode` を `.erb` / `.html.erb` に割り当て、閉じタグ・ペア記号の自動挿入を有効化
  - `yaml-mode` を `.yml` / `.yaml` に割り当て
- **LSP & 整形**（`mk-lsp.el`）
  - eglot に `ruby-lsp`（Ruby）と `vscode-html-language-server`（ERB/HTML）を登録
  - ruby-ts-mode で保存時に RuboCop 自動整形（eglot 管理下のみ）
- **Rails 専用ツール**（`mk-rails.el` 新規）
  - `inf-ruby`（REPL）、`projectile` + `projectile-rails`（ナビゲーション、`C-c r`）、`rspec-mode`（テスト）、`bundler`（Gemfile 操作）
  - `init.el` に `(require 'mk-rails)` を追加

## 確認方法

Rails プロジェクトを開いて以下を確認:

1. `.rb` を開くと `ruby-ts-mode` + eglot(ruby-lsp) が起動し補完・定義ジャンプが効く
2. 保存時に RuboCop で自動整形される
3. `C-c r m` / `C-c r v` などで Rails ナビゲーションができる
4. `.html.erb` で HTML タグ補完が出て、開きタグを閉じると閉じタグが自動挿入される

### 補足
- HTML LSP は `npm install -g vscode-langservers-extracted` が別途必要
- ruby-lsp / rubocop / rails は rbenv 経由で導入済みの想定
- ERB 内の Ruby 補完（`<%= %>` 内のヘルパー/モデル補完）は本 PR には含まれない（web-mode は HTML LSP 接続を優先）