### PR TITLE
yasnippet: js-mode スニペットの js2-node-type void エラーを修正

### DIFF
--- a/init.el
+++ b/init.el
@@ -54,8 +54,6 @@
 
 (add-to-list 'load-path "~/dev-emacs/magh")
 
-(server-start) ;; GUI Emacsをサーバーとして常駐させる
-
 (require 'mk-base)
 (require 'mk-view)
 (require 'mk-path-from-shell)

--- a/modules/mk-lsp.el
+++ b/modules/mk-lsp.el
@@ -57,6 +57,19 @@
 ;; Swift, TypeScript, ELisp など主要言語のスニペットが含まれる
 (use-package yasnippet-snippets)
 
+;; yasnippet-snippets の js-mode スニペット（*@r, *ty, *@p, @ty）は
+;; #condition: で js2-mode の関数 js2-node-type / js2-node-at-point /
+;; 変数 js2-COMMENT を参照している。js2-mode は未インストールのため、
+;; JS バッファで補完が走るたびに条件評価が void エラーになり
+;;   [yas] Error in condition evaluation: Symbol's function definition is void: js2-node-type
+;; が大量に出る。条件式が「エラー」ではなく nil を返すよう無害なスタブを置き、
+;; 該当スニペットを静かに非表示にする（(= -1 0) => nil）。
+(unless (fboundp 'js2-node-at-point)
+  (defun js2-node-at-point (&rest _) nil))
+(unless (fboundp 'js2-node-type)
+  (defun js2-node-type (_) -1))
+(defvar js2-COMMENT 0)
+
 ;; cape: 複数の補完ソース(capf)を合成・拡張する
 ;; eglot 単独だと出ない「スニペット・バッファ内の語」を補うために使う
 (use-package cape)


### PR DESCRIPTION
## 概要

このブランチでは 2 つの修正を行います。

1. `.js` ファイル等の編集中に補完のたびに大量出力されていた `js2-node-type` の void エラーを修正
2. GUI Emacs 起動時に Emacs サーバーが常駐してしまう挙動を解消

---

## 1. yasnippet: js-mode スニペットの js2-node-type void エラー

### 原因

`.js` ファイル等の編集中に、以下のエラーログが補完のたびに大量出力されていました。

```
[yas] Error in condition evaluation: Symbol's function definition is void: js2-node-type [40 times]
```

`yasnippet-snippets` が同梱する 4 つの `js-mode` スニペット（`return-comment` / `type-multiline-comment` / `param-comment` / `type-inline-comment`）の `#condition:` が、未インストールの `js2-mode` パッケージの関数 `js2-node-type` / `js2-node-at-point` と変数 `js2-COMMENT` を参照していました。

JS バッファ（`js-mode`）では `yasnippet-capf` 経由で補完のたびに各スニペットの条件式が評価されるため、`js2-node-type` が void となりエラーログが出続けていました（`yas-good-grace` が握りつぶすためクラッシュはせず、ログノイズとして顕在化）。

### 対応

`modules/mk-lsp.el` の `yasnippet-snippets` 設定直後に無害なスタブを定義し、条件式が「エラー」ではなく `nil` を返すようにしました。

```elisp
(unless (fboundp 'js2-node-at-point)
  (defun js2-node-at-point (&rest _) nil))
(unless (fboundp 'js2-node-type)
  (defun js2-node-type (_) -1))
(defvar js2-COMMENT 0)
```

`(unless (fboundp ...))` ガード付きのため、将来 `js2-mode` を導入しても本物の定義を上書きしません。

---

## 2. GUI 起動時の Emacs サーバー常駐を解消

### 原因

`init.el` で `(server-start)` を無条件に呼び出していたため、GUI Emacs を起動するたびに Emacs サーバー（daemon）が常駐していました。

### 対応

`init.el` から該当行を削除しました。

```elisp
-(server-start) ;; GUI Emacsをサーバーとして常駐させる
```

---

## 動作確認

### yasnippet 修正

- `emacs --batch` で `mk-lsp.el` の構文チェック（エラーなし）
- 条件式をバッチ評価し、`(= -1 0) => nil` となりエラーが出ないことを確認
- コメント文脈用 3 スニペットは非表示、非コメント用 `type-inline-comment`（`@ty`）のみ有効 = js2-mode 本来の通常コード位置の挙動と一致

### サーバー常駐解消

- Emacs を再起動し、`(server-running-p)` が `nil` を返すこと・起動時にサーバーが立ち上がらないことを確認
- `init.el` ロード時にエラーが出ないことを確認

## レビュー観点

- `js2-COMMENT` を `defvar 0` で定義していますが、`js2-mode` 導入時は `js2-mode` 側の定義と競合しないか（`defvar` は値未設定時のみ初期化のため実害は想定なし）
