### PR TITLE
org-mode 専用の scratch バッファを追加

### DIFF
--- a/init.el
+++ b/init.el
@@ -73,6 +73,7 @@
 (require 'mk-agent-shell)
 (require 'mk-dirvish)
 (require 'mk-org)
+(require 'mk-org-scratch)
 (require 'mk-keybind)
 (require 'mk-lsp)
 (require 'mk-language-mode)

--- a/modules/mk-org-scratch.el
+++ b/modules/mk-org-scratch.el
@@ -1,0 +1,14 @@
+;;; ============================================================
+;;; org-mode 専用のscratch バッファ
+;;; ============================================================
+(defun my/org-scratch ()
+  "org-mode 用の scratch バッファを開く"
+  (interactive)
+  (let ((buf (get-buffer-create "*org-scratch")))
+    (with-current-buffer buf
+      (unless (derived-mode-p 'org-mode)
+        (org-mode)))
+    (pop-to-buffer-same-window buf))
+  )
+
+(provide 'mk-org-scratch)

--- a/modules/mk-org-scratch.el
+++ b/modules/mk-org-scratch.el
@@ -4,7 +4,7 @@
 (defun my/org-scratch ()
   "org-mode 用の scratch バッファを開く"
   (interactive)
-  (let ((buf (get-buffer-create "*org-scratch")))
+  (let ((buf (get-buffer-create "*org-scratch*")))
     (with-current-buffer buf
       (unless (derived-mode-p 'org-mode)
         (org-mode)))


### PR DESCRIPTION
## 概要
デフォルトの `*scratch*`（`lisp-interaction-mode`）とは別に、
org-mode で書ける専用の scratch バッファを開く関数を追加しました。

ちょっとしたメモや org 記法での下書きを、Lisp 評価用の `*scratch*` を
汚さずに行えるようにするのが目的です。

## 変更内容
- `my/org-scratch` を追加。`*org-scratch*` バッファを `org-mode` で開く
- 既存バッファがあれば再利用するため、内容は保持される

## 補足
このバッファはファイルに紐づかないため、Emacs 終了時に内容は破棄されます。
永続化が必要になった場合は別途検討します。