### PR TITLE
Magit、ghostel のキーバインドを修正

### DIFF
--- a/modules/mk-ghostel.el
+++ b/modules/mk-ghostel.el
@@ -50,9 +50,9 @@
   (add-to-list 'project-switch-commands '(ghostel-project "Ghostel") t)
 
   :bind
-  ;; C-c g t : ghostel を開く
-  ("C-c g t" . ghostel)
-  ;; C-c g p : プロジェクトルートで ghostel を開く
-  ("C-c g p" . ghostel-project))
+  ;; C-c C-g t : ghostel を開く
+  ("C-c C-g t" . ghostel)
+  ;; C-c C-g p : プロジェクトルートで ghostel を開く
+  ("C-c C-g p" . ghostel-project))
 
 (provide 'mk-ghostel)

--- a/modules/mk-git.el
+++ b/modules/mk-git.el
@@ -5,7 +5,7 @@
 ;; Magit: Emacs 上で Git を操作できる強力なツール
 ;; ターミナルを開かず Git の全操作が行える
 (use-package magit
-  :bind ("C-c C-g" . magit-status))
+  :bind ("C-c g" . magit-status))
 ;;; バッファに依存せず、常にディレクトリを明示的に入力する
 (defun magit-status-ask-dir ()
   "Enter the directory to open Magit"


### PR DESCRIPTION
- **magit の起動ショートカットをC-c g に修正**
- **ghostel の起動ショートカットを C-c C-g に修正**
