### PR TITLE
ddskk を削除し C-x C-j を Emacs 標準入力に切り替え

### DIFF
--- a/modules/mk-base.el
+++ b/modules/mk-base.el
@@ -85,17 +85,4 @@
 
 (add-function :after after-focus-change-function #'my/after-focus-change)
 
-;; Setup DDSKK
-(use-package ddskk
-  :ensure t
-  :bind ("C-x C-j" . skk-mode)
-  :custom
-  (skk-large-jisyo "~/Library/Containers/net.mtgto.inputmethod.macSKK/Data/Documents/Dictionaries/skk-jisyo.utf8")
-  (skk-large-jisyo "~/Library/Containers/net.mtgto.inputmethod.macSKK/Data/Documents/Dictionaries/SKK-JISYO.L")
-  (skk-sticky-key ";")
-  (skk-show-inline t)
-  (skk-dcomp-activate t)
-  (skk-egg-like-newline t)
-  (skk-isearch-mode-enable 'always))
-
 (provide 'mk-base)

--- a/modules/mk-keybind.el
+++ b/modules/mk-keybind.el
@@ -28,6 +28,8 @@
 
 ;; Emacs標準の入力機能(LEIM)を C-x C-j で切り替える
 (setq default-input-method "japanese")
+;; 「nn」を一つの「ん」に変換する（デフォルトは n を即時確定するため nn が んん になる）
+(setq quail-japanese-use-double-n t)
 (global-set-key (kbd "C-x C-j") #'toggle-input-method)
 
 ;; C-h を削除キー（バックスペース相当）に変更する

--- a/modules/mk-keybind.el
+++ b/modules/mk-keybind.el
@@ -31,6 +31,10 @@
 ;; 「nn」を一つの「ん」に変換する（デフォルトは n を即時確定するため nn が んん になる）
 (setq quail-japanese-use-double-n t)
 (global-set-key (kbd "C-x C-j") #'toggle-input-method)
+;; Quail 中でも C-h を削除に統一する
+(with-eval-after-load 'quail
+  (define-key quail-translation-keymap "\C-h" #'quail-delete-last-char)
+  (define-key quail-conversion-keymap "\C-h" #'quail-conversion-backward-delete-char))
 
 ;; C-h を削除キー（バックスペース相当）に変更する
 ;; 理由: ターミナル環境でバックスペースが C-h として送られることが多く、

--- a/modules/mk-keybind.el
+++ b/modules/mk-keybind.el
@@ -26,6 +26,10 @@
 (global-set-key (kbd "C-SPC")  #'toggle-input-method)
 (global-set-key (kbd "C-\\") #'set-mark-command)
 
+;; Emacs標準の入力機能(LEIM)を C-x C-j で切り替える
+(setq default-input-method "japanese")
+(global-set-key (kbd "C-x C-j") #'toggle-input-method)
+
 ;; C-h を削除キー（バックスペース相当）に変更する
 ;; 理由: ターミナル環境でバックスペースが C-h として送られることが多く、
 ;;       直感的な操作に合わせる


### PR DESCRIPTION
## 概要
skk 入力は macOS のライブ変換に慣れきってしまった私には脳みその使い方的に慣れず、向いていなかった。
そのため、Emacs 標準入力の設定に戻し、C-xC-j で切り替えるように修正しました。

## 対応内容
- mk-base.el: ddskk の use-package 設定を削除
- mk-keybind.el: C-x C-j を toggle-input-method に割り当て、default-input-method を japanese に設定