### PR TITLE
multiple-cursors をセットアップ

### DIFF
--- a/init.el
+++ b/init.el
@@ -77,6 +77,7 @@
 (require 'mk-language-mode)
 (require 'mk-rails)
 (require 'mk-origami)
+(require 'mk-multiple-cursors)
 (custom-set-variables
  ;; custom-set-variables was added by Custom.
  ;; If you edit it by hand, you could mess it up, so be careful.

--- a/modules/mk-multiple-cursors.el
+++ b/modules/mk-multiple-cursors.el
@@ -1,0 +1,16 @@
+;; -*- lexical-binding: t; -*-
+
+;;; ============================================================
+;;; マルチカーソル（multiple-cursors）
+;;; ============================================================
+
+;; multiple-cursors: 複数箇所の同時編集
+;; 例: リージョン選択して C-S-c C-S-c（各行にカーソル）
+;;     C->（次の同一文字列に追加）/ C-<（前の同一文字列に追加）
+(use-package multiple-cursors
+  :bind (("C-S-c C-S-c" . mc/edit-lines)
+         ("C->" . mc/mark-next-like-this)
+         ("C-<" . mc/mark-previous-like-this)
+         ("C-c C-<" . mc/mark-all-like-this)))
+
+(provide 'mk-multiple-cursors)


### PR DESCRIPTION
## 概要
- マルチカーソルによる複数箇所同時編集のため multiple-cursors.el を導入
- 既存の origami.el 導入時と同じ構成(`modules/mk-*.el` + `init.el` への require 追加)

## キーバインド
- `C-S-c C-S-c`: 選択リージョンの各行にカーソルを追加 (`mc/edit-lines`)
- `C->` / `C-<`: 選択中の文字列と同じ箇所へ次/前方向にカーソル追加
- `C-c C-<`: 一致するすべての箇所にカーソルを追加

## テスト計画
- [x] `emacs --batch -l init.el` でエラーなく起動し、straight 経由で multiple-cursors がクローン・ビルドされることを確認
- [x] 各キーバインドが対応するコマンドに束縛されていることを確認
- [ ] 実際の Emacs 上でリージョン選択 → `C-S-c C-S-c` などの操作を確認

Closes #100