### PR TITLE
vterm での git のエディタ設定

### DIFF
--- a/modules/mk-vterm.el
+++ b/modules/mk-vterm.el
@@ -18,6 +18,7 @@
   :hook
   ;; vterm バッファでは行番号・hl-line を無効化
   (vterm-mode . (lambda ()
+                  (with-editor-export-editor)
                   ;; $EDITOR ではなく、$GIT_EDITORを優先
                   (with-editor-export-git-editor)))
   :bind

--- a/modules/mk-vterm.el
+++ b/modules/mk-vterm.el
@@ -18,8 +18,8 @@
   :hook
   ;; vterm バッファでは行番号・hl-line を無効化
   (vterm-mode . (lambda ()
-                  (display-line-numbers-mode -1)
-                  (hl-line-mode -1)))
+                  ;; $EDITOR ではなく、$GIT_EDITORを優先
+                  (with-editor-export-git-editor)))
   :bind
   ;; C-c v t : vterm を開く
   ("C-c v t" . vterm))


### PR DESCRIPTION
- **Emacs のネイティブバッファでエディタを起動するように修正**
- **update editor export editor**

vterm で、git 操作するときに、ターミナルでエディタを求められるので、Emacs のネイティブバッファを表示するように修正した。
