### PR TITLE
ruby-lsp addons (ruby-lsp-rails / ruby-lsp-rspec) の案内コメントを追加

### DIFF
--- a/modules/mk-lsp.el
+++ b/modules/mk-lsp.el
@@ -146,8 +146,17 @@
                '((python-mode python-ts-mode) . ("jedi-language-server")))
 
   ;; Ruby: ruby-lsp を使用（rbenv shim 経由で .ruby-version を尊重する）
-  ;; Rails 専用機能はプロジェクトの Gemfile に ruby-lsp-rails を入れると
-  ;; ruby-lsp が自動で addon として読み込む
+  ;; Rails / RSpec 専用機能は addon gem として提供され、プロジェクトの
+  ;; Gemfile に追加すると ruby-lsp が自動で検出して読み込む（elisp 側の追加設定は不要）:
+  ;;
+  ;;   group :development do
+  ;;     gem "ruby-lsp-rails", require: false
+  ;;     gem "ruby-lsp-rspec", require: false
+  ;;   end
+  ;;
+  ;; 注意: eglot は LSP の CodeLens に未対応のため、ruby-lsp-rspec が提供する
+  ;; 「spec 実行ボタン」自体は表示されない。spec の実行は引き続き
+  ;; rspec-mode（mk-rails.el）の C-c , v 等を使う
   (add-to-list 'eglot-server-programs
                '(ruby-ts-mode . ("ruby-lsp")))
 

--- a/modules/mk-rails.el
+++ b/modules/mk-rails.el
@@ -45,6 +45,8 @@
 
 ;; rspec-mode: spec の実行・再実行をバッファから行う
 ;; 例: C-c , v（verify file）/ C-c , s（verify single）/ C-c , r（rerun）
+;; Gemfile に ruby-lsp-rspec を追加すると ruby-lsp 側からも spec 関連の
+;; 定義ジャンプ等が効くようになる（addon 設定は mk-lsp.el を参照）
 (use-package rspec-mode
   :hook (ruby-ts-mode . rspec-mode)
   :custom


### PR DESCRIPTION
## 概要
既存の eglot + ruby-lsp（ruby-ts-mode 向け）の設定に、Rails / RSpec 向け ruby-lsp addon（ruby-lsp-rails / ruby-lsp-rspec）の案内コメントを追加。

## 変更内容
- modules/mk-lsp.el: ruby-lsp の eglot-server-programs エントリのコメントを拡張し、ruby-lsp-rails / ruby-lsp-rspec を Gemfile に追加する具体例と、eglot は LSP の CodeLens 未対応のため ruby-lsp-rspec の実行ボタンは出ない旨を明記
- modules/mk-rails.el: rspec-mode のコメントに ruby-lsp-rspec addon との連携について追記

addon は Gemfile に gem を追加するだけで ruby-lsp が自動検出するため、elisp 側の initializationOptions 追加などの機能変更は行っていない（コメントのみの変更）。

## 確認方法
- `emacs --batch -l ~/.emacs.d/init.el` でエラーなく起動することを確認済み
- Rails プロジェクトを開き `.rb` ファイルで eglot-ensure 後、ruby-lsp が起動することを確認（既存動作の非破壊確認）

## links
- https://tech.enigmo.co.jp/entry/2024/12/10/070000
- https://shopify.github.io/ruby-lsp/add-ons.html