### PR TITLE
treesit: tree-sitter grammar の導入設定を追加

### DIFF
--- a/init.el
+++ b/init.el
@@ -17,6 +17,7 @@
 (require 'mk-org)
 (require 'mk-org-scratch)
 (require 'mk-markdown)
+(require 'mk-treesit)
 (require 'mk-lsp)
 (require 'mk-lsp-manager)
 (require 'mk-language-mode)

--- a/modules/mk-language-mode.el
+++ b/modules/mk-language-mode.el
@@ -13,7 +13,7 @@
 
 ;; Ruby サポート
 ;; ruby-ts-mode は Emacs 30 組み込みの tree-sitter ベースのモード
-;; （grammar libtree-sitter-ruby は導入済み）
+;; （grammar libtree-sitter-ruby は mk-treesit.el で導入する）
 ;; .rb のほか Gemfile / Rakefile などの拡張子なしファイルも対象にする
 (use-package ruby-ts-mode
   :straight (:type built-in)

--- a/modules/mk-treesit.el
+++ b/modules/mk-treesit.el
@@ -1,0 +1,46 @@
+;; -*- lexical-binding: t; -*-
+
+;;; ============================================================
+;;; Tree-sitter（treesit）
+;;; ============================================================
+
+;; Emacs 30 組み込みの treesit は grammar を動的ライブラリとして必要とするが、
+;; treesit-language-source-alist の既定値は空なので入手先を自前で定義する。
+;; ここで定義した grammar が無いまま *-ts-mode を開くと
+;; 「Cannot activate tree-sitter, because language grammar for ... is unavailable」
+;; という警告が出る。
+;;
+;; 初回セットアップや grammar 追加時に M-x mk/treesit-install-missing-grammars を
+;; 一度実行すればよい（ビルドに時間がかかるため起動時の自動実行はしない）。
+;; インストール先は treesit-extra-load-path 未設定のため ~/.emacs.d/tree-sitter/。
+
+(use-package treesit
+  :straight (:type built-in)
+  :custom
+  ;; バージョンは Emacs 30 の grammar ABI（15）で動作するタグに固定する
+  (treesit-language-source-alist
+   '((ruby       "https://github.com/tree-sitter/tree-sitter-ruby" "v0.23.1")
+     (typescript "https://github.com/tree-sitter/tree-sitter-typescript" "v0.23.2" "typescript/src")
+     (tsx        "https://github.com/tree-sitter/tree-sitter-typescript" "v0.23.2" "tsx/src"))))
+
+(defun mk/treesit-install-missing-grammars ()
+  "未導入の tree-sitter grammar だけをビルドしてインストールする。
+既に導入済みのものは再ビルドしない。"
+  (interactive)
+  (let ((missing (seq-remove (lambda (lang) (treesit-language-available-p lang))
+                             (mapcar #'car treesit-language-source-alist)))
+        (failed nil))
+    (if (null missing)
+        (message "tree-sitter grammar は全て導入済みです")
+      (dolist (lang missing)
+        (condition-case err
+            (treesit-install-language-grammar lang)
+          (error (push (cons lang (error-message-string err)) failed))))
+      (if failed
+          (message "grammar のインストールに失敗: %s"
+                   (mapconcat (lambda (f) (format "%s (%s)" (car f) (cdr f)))
+                              (nreverse failed) ", "))
+        (message "grammar をインストールしました: %s"
+                 (mapconcat #'symbol-name missing ", "))))))
+
+(provide 'mk-treesit)


### PR DESCRIPTION
## 概要

`.rb` ファイルを開くと `Cannot activate tree-sitter, because language grammar for ruby is unavailable` という警告が出ていた。

原因は grammar の動的ライブラリが 1 つも導入されておらず、かつ `treesit-language-source-alist` が空（Emacs 30 の既定値は空）で `M-x treesit-install-language-grammar` も URL を手入力しないと使えない状態だったこと。

grammar の入手先を設定に持たせ、不足分をコマンド一発で導入できるようにする。

## 変更内容

- `modules/mk-treesit.el` を新規追加
  - `treesit-language-source-alist` に `ruby` / `typescript` / `tsx` の入手先を定義。バージョンは Emacs 30 の grammar ABI（15）で動作するタグに固定（ruby `v0.23.1`、typescript `v0.23.2`）
  - `mk/treesit-install-missing-grammars` を追加。未導入の grammar だけをビルドする冪等なコマンド。ビルドに時間がかかるため起動時の自動実行はしない
- `init.el` に `(require 'mk-treesit)` を追加
- `modules/mk-language-mode.el` のコメント「grammar libtree-sitter-ruby は導入済み」が事実と食い違っていたため修正

`.tsx` は `tsx-ts-mode` に割り当てられているため同じ警告を踏む状態だった。あわせて対象に含めている。

## 確認方法

1. Emacs を再起動し `M-x mk/treesit-install-missing-grammars` を実行する
2. `~/.emacs.d/tree-sitter/` に `libtree-sitter-{ruby,typescript,tsx}.dylib` が生成されること（このディレクトリは `.gitignore` 済み）
3. `.rb` / `.tsx` を開き、treesit の警告が出ずシンタックスハイライトとインデントが効くこと
4. 以下がすべて `t` になること

   ```elisp
   (mapcar (lambda (l) (cons l (treesit-language-available-p l)))
           '(ruby typescript tsx))
   ```

5. コマンドを再実行すると「tree-sitter grammar は全て導入済みです」となり再ビルドされないこと