### PR TITLE
Emacs Damon の表示機能を修正

### DIFF
--- a/init.el
+++ b/init.el
@@ -17,6 +17,7 @@
 (require 'mk-org)
 (require 'mk-org-scratch)
 (require 'mk-markdown)
+(require 'mk-treesit)
 (require 'mk-lsp)
 (require 'mk-lsp-manager)
 (require 'mk-language-mode)

--- a/modules/mk-dirvish.el
+++ b/modules/mk-dirvish.el
@@ -3,16 +3,27 @@
 ;;; ============================================================
 
 ;; nerd-icons: ファイルタイプに応じたアイコンを提供するパッケージ
-;; GUI 環境でのみ有意義なため、グラフィカル環境限定でロードする
+;; `dirvish-attributes' が常に参照するためロード自体は無条件に行い、
+;; グラフィカルフレームを必要とするフォント登録だけをフレーム生成時に行う。
+;; 理由: daemon 起動時は (display-graphic-p) が nil のため、ロード時判定にすると
+;;       emacsclient -c で開いた GUI フレームでアイコンが使えなくなる。
 (use-package nerd-icons
-  :if (display-graphic-p)
   :config
-  ;; Nerd Font がシステム未インストールの場合は自動でインストールする
-  ;; NFM.ttf をパッケージ同梱のものから ~/Library/Fonts/ にコピーする
-  (unless (find-font (font-spec :name "Symbols Nerd Font Mono"))
-    (nerd-icons-install-fonts t))
-  ;; Emacs の fontset に Nerd Font を登録して文字化けを防ぐ
-  (nerd-icons-set-font))
+  (defun mk--nerd-icons-setup-font (frame)
+    "グラフィカルな FRAME の生成時に Nerd Font を fontset へ登録する。"
+    (when (display-graphic-p frame)
+      (with-demoted-errors "mk-dirvish: Nerd Font の設定に失敗: %S"
+        ;; Nerd Font がシステム未インストールの場合は自動でインストールする
+        ;; NFM.ttf をパッケージ同梱のものから ~/Library/Fonts/ にコピーする
+        (unless (find-font (font-spec :name "Symbols Nerd Font Mono") frame)
+          (nerd-icons-install-fonts t))
+        ;; Emacs の fontset に Nerd Font を登録して文字化けを防ぐ
+        (nerd-icons-set-font nil frame))
+      ;; fontset は全フレーム共通なので一度成功すれば以降は不要
+      (remove-hook 'after-make-frame-functions #'mk--nerd-icons-setup-font)))
+  (if (display-graphic-p)
+      (mk--nerd-icons-setup-font (selected-frame))
+    (add-hook 'after-make-frame-functions #'mk--nerd-icons-setup-font)))
 
 ;; Dirvish: dired を大幅に強化するファイルマネージャー
 ;; dired の全機能・設定を保持しつつ、プレビュー・アイコン・

--- a/modules/mk-language-mode.el
+++ b/modules/mk-language-mode.el
@@ -13,7 +13,7 @@
 
 ;; Ruby サポート
 ;; ruby-ts-mode は Emacs 30 組み込みの tree-sitter ベースのモード
-;; （grammar libtree-sitter-ruby は導入済み）
+;; （grammar libtree-sitter-ruby は mk-treesit.el で導入する）
 ;; .rb のほか Gemfile / Rakefile などの拡張子なしファイルも対象にする
 (use-package ruby-ts-mode
   :straight (:type built-in)

--- a/modules/mk-lsp.el
+++ b/modules/mk-lsp.el
@@ -71,8 +71,10 @@
 ;; corfu-terminal: ターミナル環境でCorfuの補完ポップアップを表示する
 ;; 理由: Corfuはデフォルトでchild frameを使うため、ターミナル（TUI）では動作しない
 ;;       corfu-terminalはオーバーレイで代替表示する
+;; daemon では起動時に (display-graphic-p) が nil のためロード時判定にできない。
+;; corfu-terminal 自身がフレームごとに display-graphic-p を見て GUI では
+;; 本来の child frame 表示へ委譲するため、無条件に有効化してよい。
 (use-package corfu-terminal
-  :unless (display-graphic-p)
   :config
   (corfu-terminal-mode +1))
 
@@ -161,7 +163,6 @@
 ;; eldoc-box: eldoc の内容をカーソル位置のポップアップで表示する（GUI のみ）
 ;; VSCode の Cmd+K Cmd+I / JetBrains の F1（ドキュメント表示）に相当する
 (use-package eldoc-box
-  :if (display-graphic-p)
   :commands (eldoc-box-help-at-point))
 
 (defun mk/lsp-show-doc-at-point ()

--- a/modules/mk-treesit.el
+++ b/modules/mk-treesit.el
@@ -1,0 +1,46 @@
+;; -*- lexical-binding: t; -*-
+
+;;; ============================================================
+;;; Tree-sitter（treesit）
+;;; ============================================================
+
+;; Emacs 30 組み込みの treesit は grammar を動的ライブラリとして必要とするが、
+;; treesit-language-source-alist の既定値は空なので入手先を自前で定義する。
+;; ここで定義した grammar が無いまま *-ts-mode を開くと
+;; 「Cannot activate tree-sitter, because language grammar for ... is unavailable」
+;; という警告が出る。
+;;
+;; 初回セットアップや grammar 追加時に M-x mk/treesit-install-missing-grammars を
+;; 一度実行すればよい（ビルドに時間がかかるため起動時の自動実行はしない）。
+;; インストール先は treesit-extra-load-path 未設定のため ~/.emacs.d/tree-sitter/。
+
+(use-package treesit
+  :straight (:type built-in)
+  :custom
+  ;; バージョンは Emacs 30 の grammar ABI（15）で動作するタグに固定する
+  (treesit-language-source-alist
+   '((ruby       "https://github.com/tree-sitter/tree-sitter-ruby" "v0.23.1")
+     (typescript "https://github.com/tree-sitter/tree-sitter-typescript" "v0.23.2" "typescript/src")
+     (tsx        "https://github.com/tree-sitter/tree-sitter-typescript" "v0.23.2" "tsx/src"))))
+
+(defun mk/treesit-install-missing-grammars ()
+  "未導入の tree-sitter grammar だけをビルドしてインストールする。
+既に導入済みのものは再ビルドしない。"
+  (interactive)
+  (let ((missing (seq-remove (lambda (lang) (treesit-language-available-p lang))
+                             (mapcar #'car treesit-language-source-alist)))
+        (failed nil))
+    (if (null missing)
+        (message "tree-sitter grammar は全て導入済みです")
+      (dolist (lang missing)
+        (condition-case err
+            (treesit-install-language-grammar lang)
+          (error (push (cons lang (error-message-string err)) failed))))
+      (if failed
+          (message "grammar のインストールに失敗: %s"
+                   (mapconcat (lambda (f) (format "%s (%s)" (car f) (cdr f)))
+                              (nreverse failed) ", "))
+        (message "grammar をインストールしました: %s"
+                 (mapconcat #'symbol-name missing ", "))))))
+
+(provide 'mk-treesit)

--- a/modules/mk-view.el
+++ b/modules/mk-view.el
@@ -4,23 +4,62 @@
 (set-default-coding-systems 'utf-8)
 ;; フォント（HackGen は日本語グリフ内包のため fontset 設定不要）
 (set-face-attribute 'default nil :family "HackGen Console" :height 125)
-;; 絵文字・天気記号（☁ ⛅ 🌧 等）は HackGen 非収録のため Apple Color Emoji へフォールバック
-(when (display-graphic-p)
-  (set-fontset-font t 'emoji (font-spec :family "Apple Color Emoji") nil 'prepend)
-  (set-fontset-font t '(#x2600 . #x26FF) (font-spec :family "Apple Color Emoji") nil 'prepend)
-  (set-fontset-font t '(#x1F300 . #x1FAFF) (font-spec :family "Apple Color Emoji") nil 'prepend))
 
 ;; GUI/TUI の外観
 (use-package color-theme-sanityinc-tomorrow
   :config
   (load-theme 'sanityinc-tomorrow-night t))
 
-;; TUI時はターミナルのマウスイベントを受け取る
-(unless (display-graphic-p)
-  (set-face-background 'default "unspecified-bg")
-  (set-face-background 'line-number "unspecified-bg")
-  (set-face-background 'line-number-current-line "unspecified-bg")
+;;; ------------------------------------------------------------
+;;; フレーム種別ごとの外観設定
+;;; ------------------------------------------------------------
+;; 理由: daemon 起動時はグラフィカルフレームが存在せず (display-graphic-p) が
+;;       nil を返す。ロード時に一度だけ判定して設定すると TUI 用の設定が
+;;       グローバル指定として残り、後から emacsclient -c で作られる
+;;       GUI フレームまで壊してしまう。
+;;       そのため判定と適用はフレーム生成のたびに、そのフレームに対して行う。
+
+(defvar mk--emoji-fontset-configured nil
+  "絵文字 fontset を設定済みかどうか。
+fontset は全フレーム共通のため一度だけ実行すればよい。")
+
+(defun mk--setup-gui-frame (frame)
+  "グラフィカルな FRAME 向けの外観設定を適用する。"
+  (unless mk--emoji-fontset-configured
+    ;; 絵文字・天気記号（☁ ⛅ 🌧 等）は HackGen 非収録のため Apple Color Emoji へフォールバック
+    (with-demoted-errors "mk-view: emoji fontset の設定に失敗: %S"
+      (set-fontset-font t 'emoji (font-spec :family "Apple Color Emoji") frame 'prepend)
+      (set-fontset-font t '(#x2600 . #x26FF) (font-spec :family "Apple Color Emoji") frame 'prepend)
+      (set-fontset-font t '(#x1F300 . #x1FAFF) (font-spec :family "Apple Color Emoji") frame 'prepend)
+      (setq mk--emoji-fontset-configured t))))
+
+(defun mk--setup-tty-frame (frame)
+  "端末上の FRAME 向けの外観設定を適用する。
+`set-face-background' に FRAME を渡すことが重要。省略すると default フェイスの
+グローバル指定と `default-frame-alist' が \"unspecified-bg\" で上書きされ、
+以降に作られる GUI フレームが Unknown color で生成に失敗する。"
+  (set-face-background 'default "unspecified-bg" frame)
+  (set-face-background 'line-number "unspecified-bg" frame)
+  (set-face-background 'line-number-current-line "unspecified-bg" frame)
+  ;; ターミナルのマウスイベントを受け取る
   (xterm-mouse-mode 1))
+
+(defun mk-setup-frame-appearance (frame)
+  "FRAME の表示種別に応じた外観設定を適用する。"
+  (if (display-graphic-p frame)
+      (mk--setup-gui-frame frame)
+    (mk--setup-tty-frame frame)))
+
+(defun mk--setup-initial-frame-appearance ()
+  "起動時の初期フレームへ外観設定を適用する。"
+  (mk-setup-frame-appearance (selected-frame)))
+
+(add-hook 'after-make-frame-functions #'mk-setup-frame-appearance)
+;; 初期フレームには after-make-frame-functions が走らないため別途適用する。
+;; ロード時ではなく window-setup-hook を使うのは、起動処理の終盤で走る
+;; `frame-notice-user-settings' がフレームのフェイスを再初期化し、
+;; それより前に設定した内容が失われるため。
+(add-hook 'window-setup-hook #'mk--setup-initial-frame-appearance)
 
 ;; メニューバーを非表示
 (menu-bar-mode 0)
@@ -37,11 +76,11 @@
 ;; splash.svg の :scale default が Retina 環境でフレーム高を超え
 ;; use-fancy-splash-screens-p が nil を返す問題を修正する。
 ;; SVG が描画可能な場合は常にロゴを表示するよう advice でバイパスする。
-(when (display-graphic-p)
-  (advice-add 'use-fancy-splash-screens-p :override
-              (lambda ()
-                (and (display-graphic-p)
-                     (ignore-errors
-                       (create-image (fancy-splash-image-file)))))))
+;; advice 本体が実行時に display-graphic-p を見るため登録は無条件でよい。
+(advice-add 'use-fancy-splash-screens-p :override
+            (lambda ()
+              (and (display-graphic-p)
+                   (ignore-errors
+                     (create-image (fancy-splash-image-file))))))
 
 (provide 'mk-view)


### PR DESCRIPTION
- **treesit: tree-sitter grammar の導入設定を追加 (#191)**
- **daemon: emacsclient -c で GUI フレームが開かない問題を修正**
