### PR TITLE
行番号がズレる問題を解決

### DIFF
--- a/modules/mk-base.el
+++ b/modules/mk-base.el
@@ -26,12 +26,15 @@
 ;; 現在行をハイライト
 ;; カーソル位置を視覚的に把握しやすくする
 (global-hl-line-mode 1)
-;; 行番号を表示（絶対行番号）
+;; 行番号を表示（相対行番号）
 (setq display-line-numbers-type 'relative)
-;; 表示中の行だけでなくバッファ全体の最大行数からガター幅を決める。
-;; これをしないと相対行番号の桁数が変わるたびにガター幅が再計算され、
-;; スクロール中に本文がガタッとズレて見える。
-(setq display-line-numbers-width-start t)
+;; ガター幅を固定する。
+;; display-line-numbers-width-start はモード有効化時の行数から「最小幅」を
+;; 一度だけ決めるだけなので、追記でバッファが伸びたり、カーソルが桁の境目
+;; （9→10, 99→100）を跨ぐたびに幅が再計算されて本文がずれる。
+;; 最小幅を直接指定し、grow-only で一度広がった幅が縮まないようにする。
+(setq display-line-numbers-width 3)
+(setq display-line-numbers-grow-only t)
 (global-display-line-numbers-mode 1)
 ;; 対応する括弧をハイライト
 (show-paren-mode 1)


### PR DESCRIPTION
display-line-numbers-width-start はモード有効化時の行数から
display-line-numbers-width（最小幅）を一度だけ決めるだけで、幅を
固定するものではなかった。実際の幅は再描画のたびに表示中の行番号の
最大桁数と比較されるため、相対行番号 + 現在行の絶対表示という設定では
カーソルが桁の境目を跨いだときや、開いた後にバッファが伸びたときに
幅が伸び縮みして本文の開始位置がずれていた。

最小幅を display-line-numbers-width で直接指定し、
display-line-numbers-grow-only で一度広がった幅が縮まないようにする。
