### PR TITLE
Ruby の LSP を ruby-lsp から Solargraph に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,20 +424,20 @@ VSCode・JetBrains に近い体感になるよう設定しています。
 
 Ruby ファイルを開くと `mk-lsp-manager`（`modules/mk-lsp-manager.el`）が
 Language Server の有無を確認し、無ければ確認のうえ自動でインストールしてから
-eglot を起動します。`gem install ruby-lsp` を手動で実行する必要はありません。
+eglot を起動します。`gem install solargraph` を手動で実行する必要はありません。
 
 ```text
 Ruby ファイルを開く
   → プロジェクトの Ruby を検出（mise / rbenv / asdf / chruby / .ruby-version）
-  → ruby-lsp が無ければ「Install ruby-lsp automatically? (y or n)」
+  → solargraph が無ければ「Install solargraph automatically? (y or n)」
   → y でインストール
   → eglot 起動
 ```
 
 起動コマンドはプロジェクトごとに切り替わります。
 
-- `Gemfile.lock` に `ruby-lsp` がある → `bundle exec ruby-lsp`
-- それ以外 → プロジェクトの Ruby に入っている `ruby-lsp`
+- `Gemfile.lock` に `solargraph` がある → `bundle exec solargraph stdio`
+- それ以外 → プロジェクトの Ruby に入っている `solargraph stdio`
 
 macOS の system Ruby（`/usr/bin/ruby`）には gem をインストールしません
 （`sudo gem install` は実行しません）。その場合は mise / rbenv などの
@@ -445,7 +445,7 @@ Ruby 環境を用意してください。
 
 | コマンド | 動作 |
 |------|------|
-| `M-x mk-lsp-manager-status` | 検出した Ruby・ruby-lsp・eglot の状態を表示 |
+| `M-x mk-lsp-manager-status` | 検出した Ruby・solargraph・eglot の状態を表示 |
 | `M-x mk-lsp-manager-install` | Language Server を手動でインストール |
 | `M-x mk-lsp-manager-refresh` | 環境の再検出（Ruby を切り替えた後などに実行） |
 
@@ -457,13 +457,42 @@ Ruby 環境を用意してください。
 (setq mk-lsp-manager-confirm-install t) ; インストール前に確認する
 ```
 
-Rails / RSpec 向けの機能は addon gem をプロジェクトの Gemfile に追加すると
-ruby-lsp が自動で読み込みます。
+Rails / RSpec 向けの型情報は addon gem をプロジェクトの Gemfile に追加すると
+Solargraph が読み込みます（`bundle exec solargraph` で起動したときに有効）。
 
 ```ruby
 group :development do
-  gem "ruby-lsp-rails", require: false
-  gem "ruby-lsp-rspec", require: false
+  gem "solargraph", require: false
+  gem "solargraph-rails", require: false
+  gem "solargraph-rspec", require: false
+end
+```
+
+実行時にしか分からない情報（`rails console` 上のオブジェクトなど）は
+Solargraph では追えないため、robe で補います。
+
+| キー / コマンド | 動作 |
+|------|------|
+| `M-x inf-ruby` / `M-x inf-ruby-console-auto` | REPL を起動 |
+| `M-x robe-start` | 起動中の REPL に robe を接続 |
+| `C-c l j` | robe で定義へジャンプ（実行時情報を使う） |
+| `C-c l k` | robe でドキュメントを表示 |
+
+補完候補は Solargraph に一本化しており、robe は補完には出しません。
+
+Solargraph はブロック引数の型までは推論しないため、以下のようなケースでは
+`# @type` を書くと補完が効くようになります。
+
+```ruby
+numbers = [1, 2, 3]
+numbers.each do |num|
+  num.        # 候補が出ない（num の型が不明）
+end
+
+# @type [Array<Integer>]
+numbers = [1, 2, 3]
+numbers.each do |num|
+  num.        # Integer のメソッドが出る
 end
 ```
 
@@ -565,7 +594,7 @@ npm install -g typescript-language-server typescript
 
 **LSP が起動しない（Ruby）**
 
-`M-x mk-lsp-manager-status` で、検出された Ruby・ruby-lsp のパス・実行コマンドを
+`M-x mk-lsp-manager-status` で、検出された Ruby・solargraph のパス・実行コマンドを
 確認します。Ruby を切り替えた直後は `M-x mk-lsp-manager-refresh` で再検出させます。
 インストールの詳細な出力は `*mk-lsp-manager*` バッファに残ります。
 

--- a/modules/mk-lsp-manager.el
+++ b/modules/mk-lsp-manager.el
@@ -146,9 +146,21 @@ DESCRIBE … 引数なし。status 表示用の (ラベル . 値) リストを�
         (let ((out (string-trim (buffer-string))))
           (unless (string-empty-p out) out))))))
 
+(defcustom mk-lsp-manager-build-environment
+  '("CC=/usr/bin/clang" "CXX=/usr/bin/clang++")
+  "インストール処理に上書きで渡す環境変数。
+
+理由: 環境変数 CC に gcc などを設定していると、ネイティブ拡張を含む gem
+      （solargraph が依存する jaro_winkler など）のビルドが失敗することがある。
+      インストール時だけ標準のコンパイラを使わせる。"
+  :type '(repeat string)
+  :group 'mk-lsp-manager)
+
 (defun mk-lsp-manager--run-async (label command directory callback)
   "COMMAND を DIRECTORY で非同期実行し、終了時に (funcall CALLBACK 成否) を呼ぶ。"
   (let ((buffer (get-buffer-create mk-lsp-manager--process-buffer))
+        (process-environment (append mk-lsp-manager-build-environment
+                                     process-environment))
         (default-directory (file-name-as-directory directory)))
     (with-current-buffer buffer
       (goto-char (point-max))
@@ -170,21 +182,23 @@ DESCRIBE … 引数なし。status 表示用の (ラベル . 値) リストを�
 ;;; Ruby バックエンド
 ;;; ============================================================
 ;;
-;; ruby-lsp は「プロジェクトが使っている Ruby」で起動する必要がある。
+;; Solargraph は「プロジェクトが使っている Ruby」で起動する必要がある。
 ;; そのため PATH 先頭の ruby ではなく、mise / rbenv / asdf / chruby に
 ;; プロジェクトディレクトリで問い合わせて実行環境を決める。
 ;;
-;; Rails / RSpec 専用機能は addon gem として提供され、プロジェクトの
-;; Gemfile に追加すると ruby-lsp が自動で検出して読み込む:
+;; Rails / RSpec 専用の型情報は addon gem として提供される。プロジェクトの
+;; Gemfile に追加して bundle install すると、bundle exec 経由で起動した
+;; Solargraph が自動で読み込む:
 ;;
 ;;   group :development do
-;;     gem "ruby-lsp-rails", require: false
-;;     gem "ruby-lsp-rspec", require: false
+;;     gem "solargraph", require: false
+;;     gem "solargraph-rails", require: false
+;;     gem "solargraph-rspec", require: false
 ;;   end
 ;;
-;; 注意: eglot は LSP の CodeLens に未対応のため、ruby-lsp-rspec が提供する
-;; 「spec 実行ボタン」自体は表示されない。spec の実行は引き続き
-;; rspec-mode（mk-rails.el）の C-c , v 等を使う。
+;; 実行時にしか分からない情報（rails console 上のオブジェクトなど）は
+;; Solargraph では追えないため、robe（mk-rails.el）で補う。
+;; spec の実行は rspec-mode（mk-rails.el）の C-c , v 等を使う。
 
 (defconst mk-lsp-manager--ruby-system-regexp
   "\\`\\(/usr/bin/\\|/System/\\|/Library/Ruby/\\)"
@@ -242,16 +256,16 @@ DESCRIBE … 引数なし。status 表示用の (ラベル . 値) リストを�
     (split-string out "\n" t)))
 
 (defun mk-lsp-manager--ruby-bundled-p (root)
-  "ROOT の Gemfile.lock に ruby-lsp が含まれるなら非 nil。"
+  "ROOT の Gemfile.lock に solargraph が含まれるなら非 nil。"
   (let ((lock (expand-file-name "Gemfile.lock" root)))
     (and (file-readable-p lock)
          (with-temp-buffer
            (insert-file-contents lock)
            (goto-char (point-min))
-           (and (re-search-forward "^ +ruby-lsp (" nil t) t)))))
+           (and (re-search-forward "^ +solargraph (" nil t) t)))))
 
 (defun mk-lsp-manager--ruby-state (&optional force)
-  "現在のバッファに対応する Ruby / ruby-lsp の状態を plist で返す。
+  "現在のバッファに対応する Ruby / Solargraph の状態を plist で返す。
 
 FORCE が非 nil ならキャッシュを無視して再検出する。
 外部コマンドを数回呼ぶため、プロジェクトルート単位でキャッシュする。"
@@ -266,12 +280,12 @@ FORCE が非 nil ならキャッシュを無視して再検出する。
                                                  (file-truename ruby))))
                (bin-dirs (and ruby (mk-lsp-manager--ruby-bin-directories ruby)))
                (gem-exe (mk-lsp-manager--ruby-gem-executable ruby bin-dirs))
-               (ruby-lsp (mk-lsp-manager--ruby-sibling ruby bin-dirs "ruby-lsp"))
-               ;; Gemfile.lock に ruby-lsp があり、かつ実際に gem が入っている
+               (solargraph (mk-lsp-manager--ruby-sibling ruby bin-dirs "solargraph"))
+               ;; Gemfile.lock に solargraph があり、かつ実際に gem が入っている
                ;; ときだけ bundle exec を使う。lock に載っているだけの状態で
                ;; bundle exec を選ぶと、bundler が解決のためにネットワークへ
                ;; 出ていき Eglot の起動が固まるため、ここでは外部コマンドを叩かない
-               (bundle-exe (and ruby-lsp
+               (bundle-exe (and solargraph
                                 (mk-lsp-manager--ruby-bundled-p root)
                                 (mk-lsp-manager--ruby-sibling ruby bin-dirs "bundle")))
                (state (list :root root
@@ -281,9 +295,9 @@ FORCE が非 nil ならキャッシュを無視して再検出する。
                             :system (and system t)
                             :gem gem-exe
                             :bundler (and bundle-exe t)
-                            :executable (or bundle-exe ruby-lsp)
-                            :command (cond (bundle-exe (list bundle-exe "exec" "ruby-lsp"))
-                                           (ruby-lsp (list ruby-lsp))))))
+                            :executable (or bundle-exe solargraph)
+                            :command (cond (bundle-exe (list bundle-exe "exec" "solargraph" "stdio"))
+                                           (solargraph (list solargraph "stdio"))))))
           (puthash root state mk-lsp-manager--ruby-cache)
           state))))
 
@@ -315,7 +329,7 @@ FORCE が非 nil ならキャッシュを無視して再検出する。
 (defun mk-lsp-manager--ruby-failure-help (state command)
   "インストール失敗時に表示する診断メッセージを組み立てる。"
   (concat
-   "[mk-lsp-manager] ruby-lsp のインストールに失敗しました\n"
+   "[mk-lsp-manager] solargraph のインストールに失敗しました\n"
    (format "  使用した Ruby : %s\n" (or (plist-get state :ruby) "(見つかりません)"))
    (format "  Ruby バージョン: %s\n" (or (plist-get state :version) "(不明)"))
    (format "  バージョン管理 : %s\n" (plist-get state :manager))
@@ -324,11 +338,11 @@ FORCE が非 nil ならキャッシュを無視して再検出する。
    "  対処方法:\n"
    (format "    1. ターミナルで `cd %s` してから上記コマンドを手動実行し、エラーを確認する\n"
            (plist-get state :root))
-   "    2. Gemfile で管理する場合は Gemfile に gem \"ruby-lsp\", require: false を追加して bundle install する\n"
+   "    2. Gemfile で管理する場合は Gemfile に gem \"solargraph\", require: false を追加して bundle install する\n"
    (format "    3. 詳しい出力は %s バッファを参照する" mk-lsp-manager--process-buffer)))
 
 (defun mk-lsp-manager--ruby-install (callback)
-  "現在のプロジェクトの Ruby に ruby-lsp をインストールする。"
+  "現在のプロジェクトの Ruby に solargraph をインストールする。"
   (let* ((state (mk-lsp-manager--ruby-state t))
          (ruby (plist-get state :ruby))
          (gem (plist-get state :gem)))
@@ -339,7 +353,7 @@ FORCE が非 nil ならキャッシュを無視して再検出する。
      ;; macOS の system Ruby には絶対にインストールしない（sudo も実行しない）
      ((plist-get state :system)
       (message (concat "[mk-lsp-manager] 現在の Ruby は macOS system Ruby です（%s）。\n"
-                       "  ruby-lsp をインストールするには mise / rbenv などの Ruby 環境を使用してください。\n"
+                       "  solargraph をインストールするには mise / rbenv などの Ruby 環境を使用してください。\n"
                        "  例: rbenv install 3.4.5 && rbenv local 3.4.5\n"
                        "  （sudo gem install は実行しません）")
                ruby)
@@ -348,10 +362,10 @@ FORCE が非 nil ならキャッシュを無視して再検出する。
       (message "[mk-lsp-manager] gem コマンドが見つかりません（Ruby: %s）" ruby)
       (funcall callback nil))
      (t
-      (let ((command (list gem "install" "ruby-lsp")))
-        (message "Installing ruby-lsp...")
+      (let ((command (list gem "install" "solargraph")))
+        (message "Installing solargraph...")
         (mk-lsp-manager--run-async
-         "ruby-lsp" command (plist-get state :root)
+         "solargraph" command (plist-get state :root)
          (lambda (success)
            (when (and success (eq 'rbenv (plist-get state :manager)))
              ;; rbenv は shim を作り直さないと新しい実行ファイルが見えない
@@ -359,7 +373,7 @@ FORCE が非 nil ならキャッシュを無視して再検出する。
                (mk-lsp-manager--call rbenv "rehash")))
            (clrhash mk-lsp-manager--ruby-cache)
            (if success
-               (message "ruby-lsp installed successfully.")
+               (message "solargraph installed successfully.")
              (message "%s" (mk-lsp-manager--ruby-failure-help state command)))
            (funcall callback success))))))))
 
@@ -376,15 +390,15 @@ FORCE が非 nil ならキャッシュを無視して再検出する。
      (cons "Ruby version" (or (plist-get state :version) "(不明)"))
      (cons "system Ruby" (if (plist-get state :system) "yes（インストール禁止）" "no"))
      (cons "Gemfile" (if (file-readable-p (expand-file-name "Gemfile" root)) "yes" "no"))
-     (cons "ruby-lsp in Gemfile.lock" (if (plist-get state :bundler) "yes" "no"))
-     (cons "ruby-lsp" (if (plist-get state :executable) "installed" "not installed"))
-     (cons "ruby-lsp path" (or (plist-get state :executable) "-"))
+     (cons "solargraph in Gemfile.lock" (if (plist-get state :bundler) "yes" "no"))
+     (cons "solargraph" (if (plist-get state :executable) "installed" "not installed"))
+     (cons "solargraph path" (or (plist-get state :executable) "-"))
      (cons "command" (if-let* ((cmd (plist-get state :command)))
                          (mapconcat #'shell-quote-argument cmd " ")
                        "-")))))
 
 (mk-lsp-manager-register-server
- :id 'ruby-lsp
+ :id 'solargraph
  :name "Ruby"
  :modes '(ruby-ts-mode ruby-mode)
  :locate #'mk-lsp-manager--ruby-locate
@@ -400,7 +414,7 @@ FORCE が非 nil ならキャッシュを無視して再検出する。
 (defun mk-lsp-manager-eglot-contact (&optional _interactive _project)
   "`eglot-server-programs' に登録する動的コンタクト。
 
-バッファごとに `bundle exec ruby-lsp' と実体パスを出し分ける。"
+バッファごとに `bundle exec solargraph' と実体パスを出し分ける。"
   (when-let* ((server (mk-lsp-manager-server-for-mode major-mode)))
     (mk-lsp-manager-server-command server)))
 

--- a/modules/mk-lsp.el
+++ b/modules/mk-lsp.el
@@ -110,8 +110,8 @@
   :config
   ;; cape-keyword: 言語ごとの予約語を補完候補に出す
   (require 'cape-keyword)
-  ;; ruby-lsp は raise などレシーバなしの Kernel メソッドを補完候補に
-  ;; 返さないため、頻出のものを予約語リストに足して補完に出す
+  ;; Solargraph はレシーバなしの Kernel メソッド（raise 等）を候補に
+  ;; 出さないことがあるため、頻出のものを予約語リストに足して補完に出す
   ;; （ruby-ts-mode は cape-keyword-list 内で ruby-mode のリストを参照する）
   (dolist (kw '("raise" "puts" "p" "pp" "require" "require_relative"
                 "lambda" "proc" "loop" "throw" "catch"))
@@ -190,7 +190,7 @@ GUI では eldoc-box のポップアップ、TUI では eldoc のバッファを
    (tsx-ts-mode      . eglot-ensure)
    (python-mode      . eglot-ensure)
    (python-ts-mode   . eglot-ensure)
-   ;; Ruby は mk-lsp-manager がサーバーの有無を確認してから起動する
+   ;; Ruby（Solargraph）は mk-lsp-manager がサーバーの有無を確認してから起動する
    (web-mode         . eglot-ensure))
 
   :config
@@ -210,8 +210,15 @@ GUI では eldoc-box のポップアップ、TUI では eldoc のバッファを
   (add-to-list 'eglot-server-programs
                '((python-mode python-ts-mode) . ("jedi-language-server")))
 
-  ;; Ruby: ruby-lsp の検出・インストール・起動は mk-lsp-manager.el が担当する
+  ;; Ruby: Solargraph の検出・インストール・起動は mk-lsp-manager.el が担当する
   ;; （プロジェクトの Ruby / bundler を解決する必要があるため）
+
+  ;; Solargraph は診断とフォーマットが既定で無効なので明示的に有効化する
+  ;; （どちらも Solargraph が依存する RuboCop を使うため追加インストールは不要）
+  ;; RuboCop 設定のない単発スクリプトでは既定 cop の指摘が大量に出るため、
+  ;; うるさければ :diagnostics :json-false に落とす
+  (setq-default eglot-workspace-configuration
+                '(:solargraph (:diagnostics t :formatting t)))
 
   ;; HTML/ERB: vscode-html-language-server を使用
   ;; web-mode で HTML タグ・属性の補完を corfu に出すため
@@ -244,11 +251,18 @@ GUI では eldoc-box のポップアップ、TUI では eldoc のバッファを
 ;; eglot が管理しているバッファのみフォーマットする
 ;; 理由: LSP 未接続のときに eglot-format-buffer を呼ぶとエラーになるため
 (defun mk/eglot-format-on-save ()
-  "eglot 管理下のバッファを保存前にフォーマットする。"
-  (when (bound-and-true-p eglot--managed-mode)
-    (eglot-format-buffer)))
+  "eglot 管理下のバッファを保存前にフォーマットする。
 
-;; Ruby: 保存時に ruby-lsp（RuboCop）で自動整形する
+フォーマットに失敗しても保存自体は止めない。
+理由: Solargraph の整形は RuboCop に委ねられており、RuboCop の設定を
+      解決できないプロジェクトではサーバーがエラーを返すため。"
+  (when (bound-and-true-p eglot--managed-mode)
+    (condition-case err
+        (eglot-format-buffer)
+      (error (message "[mk-lsp] 保存時のフォーマットをスキップしました: %s"
+                      (error-message-string err))))))
+
+;; Ruby: 保存時に Solargraph（RuboCop）で自動整形する
 ;; 手動整形は引き続き C-c l f が使える
 (add-hook 'ruby-ts-mode-hook
           (lambda ()
@@ -269,8 +283,9 @@ GUI では eldoc-box のポップアップ、TUI では eldoc のバッファを
 ;;     （第1要素が候補を返す間は Dabbrev は出ないので Method がノイズに埋もれない）
 ;;
 ;; eglot 側は cape-capf-buster でラップする。
-;; 理由: ruby-lsp のように候補をサーバー側でフィルタして isIncomplete で返す
-;;       サーバーでは入力のたびに再クエリが必要だが、cape-capf-super は候補を
+;; 理由: 入力に応じてサーバー側で候補を絞り込むサーバー（Solargraph の
+;;       `numbers.` のようなレシーバ補完もこれに当たる）では入力のたびに
+;;       再クエリが必要だが、cape-capf-super は候補を
 ;;       キャッシュするため再クエリが止まり、プロジェクト定義の定数などが
 ;;       補完に出なくなる。buster がキャッシュを無効化して毎回再クエリさせる。
 (defun mk/eglot-capf ()

--- a/modules/mk-rails.el
+++ b/modules/mk-rails.el
@@ -13,6 +13,31 @@
   (ruby-ts-mode . inf-ruby-minor-mode))
 
 
+;; robe: 起動中の Ruby プロセスに問い合わせる runtime-aware なコード探索
+;; 理由: Solargraph は静的解析なので、Rails の動的定義（has_many が生やす
+;;       メソッド、ActiveRecord の属性など）や RSpec の let で定義された
+;;       ヘルパを追えない。実行中のプロセスに聞ける robe がそこを補う。
+;; 補完は Solargraph に一本化し、robe は定義ジャンプとドキュメント参照に使う
+;; 使い方: M-x inf-ruby（Rails なら M-x inf-ruby-console-auto）で REPL を
+;;         起動してから M-x robe-start する
+(use-package robe
+  :hook (ruby-ts-mode . robe-mode)
+  ;; M-. は eglot（Solargraph）の xref バックエンドが優先される
+  ;; （robe も xref バックエンドを足すが、後から有効になる eglot が先に来る。
+  ;;   robe を使ったジャンプは下のキーから明示的に呼ぶ）
+  :bind (:map robe-mode-map
+              ("C-c l j" . robe-jump)
+              ("C-c l k" . robe-doc))
+  :config
+  ;; robe-mode は自身の補完関数を completion-at-point-functions に足すため、
+  ;; そのままだと Solargraph と同じ候補が二重に出る。
+  ;; 補完ソースは Solargraph に一本化し、robe は探索用途に限定する
+  (defun mk/robe-disable-capf ()
+    "robe の補完を completion-at-point から外す。"
+    (remove-hook 'completion-at-point-functions #'robe-complete-at-point t))
+  (add-hook 'robe-mode-hook #'mk/robe-disable-capf))
+
+
 ;;; ============================================================
 ;;; プロジェクト操作・Rails ナビゲーション
 ;;; ============================================================
@@ -45,8 +70,9 @@
 
 ;; rspec-mode: spec の実行・再実行をバッファから行う
 ;; 例: C-c , v（verify file）/ C-c , s（verify single）/ C-c , r（rerun）
-;; Gemfile に ruby-lsp-rspec を追加すると ruby-lsp 側からも spec 関連の
-;; 定義ジャンプ等が効くようになる（addon 設定は mk-lsp.el を参照）
+;; Gemfile に solargraph-rspec を追加すると Solargraph 側でも
+;; describe / let などの RSpec DSL を解釈できるようになる
+;;（Ruby 環境の解決は mk-lsp-manager.el を参照）
 (use-package rspec-mode
   :hook (ruby-ts-mode . rspec-mode)
   :custom


### PR DESCRIPTION
## 概要

Ruby のメイン LSP を ruby-lsp から Solargraph に変更する。

`numbers = [12, 34, 56]` に対して `numbers.` と打っても Array / Enumerable のメソッドが補完されなかったため、静的解析で標準ライブラリの型情報を持つ Solargraph に乗り換える。実行時にしか分からない情報（Rails の動的定義など）は robe で補う。

## 変更内容

- `mk-lsp-manager`: Ruby バックエンドの gem と起動コマンドを `solargraph stdio`（`Gemfile.lock` にあれば `bundle exec solargraph stdio`）に差し替え
- `mk-lsp-manager`: gem のインストール時だけ `CC` / `CXX` を clang に上書きし、ネイティブ拡張のビルドが環境変数 `CC` の影響で失敗しないようにする
- `mk-lsp`: Solargraph の診断とフォーマットを `eglot-workspace-configuration` で有効化。保存時のフォーマットが失敗しても保存を止めないようにする
- `mk-rails`: robe を追加。補完は Solargraph に一本化し（robe の capf は除去）、robe は実行時情報を使ったジャンプ `C-c l j` とドキュメント `C-c l k` に使う
- `README`: Ruby の LSP まわりの記述を更新

Eglot への登録（`eglot-server-programs` の関数コンタクト）と `ruby-base-mode-hook` は変更していない。Corfu / Orderless / cape / yasnippet の設定も変更なし。

## 確認方法

1. `gem install solargraph`（未導入なら Emacs が確認のうえ自動インストールする）
2. Emacs を再起動して `.rb` ファイルを開く
3. `M-x mk-lsp-manager-status` で `solargraph: installed` と `command: …/solargraph stdio` を確認
4. 以下を入力して Corfu に `each` / `map` / `select` などが出ること

   ```ruby
   numbers = [12, 34, 56, 78, 90]
   numbers.
   ```

### 確認済みの範囲

実際の `init.el` を読み込んだ Emacs で、バッファに `.` を入力して `completion-at-point-functions` から候補を取得して確認した。

- `numbers.` → LSP から 174 件（`each` `map` `select` `sum` `min` `max` `sort` `all?` `any?` `filter` `append` すべて含む）
- `text.` → LSP から 164 件（`upcase` `downcase` `split` `strip` 含む）

### 既知の制限

ブロック引数は Solargraph が型を推論できず候補が出ない。`# @type [Array<Integer>]` を書けば出ることは確認済みで、README に追記した。

```ruby
numbers.each do |num|
  num.   # 候補が出ない
end
```

Rails / RSpec の補完は手元に対象プロジェクトが無く未確認。`solargraph-rails` / `solargraph-rspec` はプロジェクト側の Gemfile 依存。